### PR TITLE
[codex] Fix preview test and extend mocha timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,3 +41,7 @@ jobs:
     - run: npm run test -- packages/poml/tests
       if: runner.os != 'Linux'
     - run: python -m pytest python/tests
+    - run: xvfb-run -a npm run compile && xvfb-run -a npm run test-vscode
+      if: runner.os == 'Linux'
+    - run: npm run compile && npm run test-vscode
+      if: runner.os != 'Linux'

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -1,5 +1,5 @@
 import { defineConfig } from '@vscode/test-cli';
 
 export default defineConfig({
-  files: 'out/test/**/*.test.js'
+  files: 'out/poml-vscode/tests/**/*.test.js'
 });

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,6 @@ module.exports = {
   transform: {
     '^.+.tsx?$': ['ts-jest', {}],
   },
-  roots: ['<rootDir>/packages/poml/tests', '<rootDir>/packages/poml-vscode/tests'],
+  roots: ['<rootDir>/packages/poml/tests'],
   moduleDirectories: ['node_modules', 'packages']
 };

--- a/packages/poml-vscode/test-fixtures/test.poml
+++ b/packages/poml-vscode/test-fixtures/test.poml
@@ -1,0 +1,1 @@
+<p speaker="ai">hello</p>

--- a/packages/poml-vscode/tests/commands.test.ts
+++ b/packages/poml-vscode/tests/commands.test.ts
@@ -1,0 +1,22 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+
+suite('Commands', () => {
+  test('expected commands are registered', async () => {
+    const cmds = await vscode.commands.getCommands(true);
+    const expected = [
+      'poml.test',
+      'poml.testNonChat',
+      'poml.testRerun',
+      'poml.testAbort',
+      'poml.showPreview',
+      'poml.showPreviewToSide',
+      'poml.showLockedPreviewToSide',
+      'poml.showSource',
+      'poml.telemetry.completion',
+    ];
+    for (const id of expected) {
+      assert.ok(cmds.includes(id), `Missing command ${id}`);
+    }
+  });
+});

--- a/packages/poml-vscode/tests/extension.test.ts
+++ b/packages/poml-vscode/tests/extension.test.ts
@@ -1,15 +1,11 @@
 import * as assert from 'assert';
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 import * as vscode from 'vscode';
-// import * as myExtension from '../../extension';
 
-suite('Extension Test Suite', () => {
-  vscode.window.showInformationMessage('Start all tests.');
-
-  test('Sample test', () => {
-    assert.strictEqual(-1, [1, 2, 3].indexOf(5));
-    assert.strictEqual(-1, [1, 2, 3].indexOf(0));
+suite('Extension Activation', () => {
+  test('extension activates', async () => {
+    const ext = vscode.extensions.getExtension('poml-team.poml');
+    assert.ok(ext, 'Extension not found');
+    await ext?.activate();
+    assert.ok(ext?.isActive, 'Extension did not activate');
   });
 });

--- a/packages/poml-vscode/tests/panelContent.test.ts
+++ b/packages/poml-vscode/tests/panelContent.test.ts
@@ -1,22 +1,24 @@
-// import { pomlVscodePanelContent } from 'poml-vscode/panel/content';
+import * as assert from 'assert';
+import { pomlVscodePanelContent } from '../panel/content';
 
-// const document = '<p><p speaker="ai">hello</p><p speaker="human">world</p></p>'
-
-// export function playground() {
-//   const content = pomlVscodePanelContent({
-//     source: 'source',
-//     line: 0,
-//     lineCount: 0,
-//     locked: false,
-//     scrollEditorWithPreview: false,
-//     doubleClickToSwitchToEditor: false,
-//     speakerMode: true,
-//     displayFormat: 'rendered',
-//     document: document,
-//     extensionResourcePath: (path: string) => path,
-//     localResourcePath: (path: string) => path,
-//   });
-//   console.log(content);
-// }
-
-// playground();
+suite('Panel content helper', () => {
+  test('basic rendering works', () => {
+    const html = pomlVscodePanelContent({
+      source: 'source',
+      line: 0,
+      lineCount: 1,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: false,
+      speakerMode: true,
+      displayFormat: 'rendered',
+      rawText: '<p>test</p>',
+      ir: '',
+      content: [],
+      extensionResourcePath: (p: string) => p,
+      localResourcePath: (p: string) => p,
+    });
+    assert.ok(html.includes('test'));
+  });
+});

--- a/packages/poml-vscode/tests/preview.test.ts
+++ b/packages/poml-vscode/tests/preview.test.ts
@@ -1,0 +1,17 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+suite('Preview Feature', () => {
+  test('showPreview executes without error', async function() {
+    this.timeout(10000);
+    const sample = path.resolve(__dirname, '../../../packages/poml-vscode/test-fixtures/test.poml');
+    const uri = vscode.Uri.file(sample);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc);
+    await vscode.commands.executeCommand('poml.showPreview', uri);
+    // give VS Code some time to process
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
## Summary
- remove jest mocks and convert vscode extension tests to mocha
- configure vscode-test runner and point to compiled test path
- add preview fixture file and update workflow to run vscode tests
- test preview command, command registration, and extension activation

## Testing
- `npm test -- -w=packages/poml/tests`
- `xvfb-run -a npm run test-vscode`


------
https://chatgpt.com/codex/tasks/task_e_6853afb47a1c832e91d8c01ae716bf30