### PR TITLE
Add tracing tests and buffer serialization

### DIFF
--- a/packages/poml/tests/trace.test.tsx
+++ b/packages/poml/tests/trace.test.tsx
@@ -1,0 +1,41 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+import { commandLine, setTrace, clearTrace, parseJsonWithBuffers, dumpTrace } from 'poml';
+
+function stringifyWithBuffers(obj: any): string {
+  return JSON.stringify(obj, (_k, v) => {
+    if (Buffer.isBuffer(v)) {
+      return { __base64__: v.toString('base64') };
+    }
+    return v;
+  });
+}
+
+describe('trace dumps', () => {
+  let traceDir: string;
+  beforeEach(() => {
+    traceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-'));
+    setTrace(true, traceDir);
+  });
+  afterEach(() => {
+    clearTrace();
+    fs.rmSync(traceDir, { recursive: true, force: true });
+  });
+
+  test('unused buffer in context is dumped', async () => {
+    const buffer = fs.readFileSync(path.join(__dirname, 'assets', 'tomCat.jpg'));
+    dumpTrace('<p></p>', { img: buffer });
+    const raw = fs.readFileSync(path.join(traceDir, '0001_context.json'), 'utf8');
+    expect(raw).toContain('__base64__');
+  });
+
+  test('document result includes base64', async () => {
+    const markup = `<Document src="${path.join(__dirname, 'assets', 'sampleWord.docx')}" />`;
+    await commandLine({ input: markup, speakerMode: false });
+    const result = parseJsonWithBuffers(fs.readFileSync(path.join(traceDir, '0001_result.json'), 'utf8'));
+    const images = JSON.stringify(result).includes('base64');
+    expect(images).toBe(true);
+  });
+});

--- a/packages/poml/trace.ts
+++ b/packages/poml/trace.ts
@@ -1,0 +1,108 @@
+import { mkdirSync, writeFileSync, openSync, closeSync, writeSync, readFileSync } from 'fs';
+import path from 'path';
+
+interface Base64Wrapper { __base64__: string }
+
+function replaceBuffers(value: any): any {
+  if (Buffer.isBuffer(value)) {
+    const wrapper: Base64Wrapper = { __base64__: value.toString('base64') };
+    return wrapper;
+  } else if (Array.isArray(value)) {
+    return value.map(replaceBuffers);
+  } else if (value && typeof value === 'object') {
+    const result: any = {};
+    for (const k of Object.keys(value)) {
+      result[k] = replaceBuffers(value[k]);
+    }
+    return result;
+  }
+  return value;
+}
+
+export function parseJsonWithBuffers(text: string): any {
+  return JSON.parse(text, (_key, value) => {
+    if (value && typeof value === 'object' && value.__base64__) {
+      return Buffer.from(value.__base64__, 'base64');
+    }
+    return value;
+  });
+}
+
+let traceEnabled = false;
+let traceDir: string | undefined;
+
+export function setTrace(enabled = true, dir?: string): string | undefined {
+  traceEnabled = enabled;
+  if (!enabled) {
+    traceDir = undefined;
+    return undefined;
+  }
+  const envDir = process.env.POML_TRACE;
+  if (dir) {
+    const base = path.resolve(dir);
+    mkdirSync(base, { recursive: true });
+    traceDir = base;
+    process.env.POML_TRACE = traceDir;
+  } else if (envDir) {
+    mkdirSync(envDir, { recursive: true });
+    traceDir = envDir;
+  } else {
+    traceDir = undefined;
+  }
+  return traceDir;
+}
+
+export function clearTrace() {
+  traceEnabled = false;
+  traceDir = undefined;
+  delete process.env.POML_TRACE;
+}
+
+export function isTracing(): boolean {
+  return traceEnabled && !!traceDir;
+}
+
+function nextIndex(): [number, string, number] {
+  if (!traceDir) {
+    return [0, '', -1];
+  }
+  for (let i = 1; ; i++) {
+    const idxStr = i.toString().padStart(4, '0');
+    const prefix = path.join(traceDir, idxStr);
+    const filePath = `${prefix}_markup.poml`;
+    try {
+      const fd = openSync(filePath, 'wx');
+      return [i, prefix, fd];
+    } catch (err: any) {
+      if (err.code === 'EEXIST') {
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+export function dumpTrace(markup: string, context?: any, stylesheet?: any, result?: any) {
+  if (!isTracing()) {
+    return;
+  }
+  const [_idx, prefix, fd] = nextIndex();
+  try {
+    writeSync(fd, markup);
+  } finally {
+    closeSync(fd);
+  }
+  if (context && Object.keys(context).length > 0) {
+    writeFileSync(`${prefix}_context.json`, JSON.stringify(replaceBuffers(context), null, 2));
+  }
+  if (stylesheet && Object.keys(stylesheet).length > 0) {
+    writeFileSync(`${prefix}_stylesheet.json`, JSON.stringify(replaceBuffers(stylesheet), null, 2));
+  }
+  if (result !== undefined) {
+    writeFileSync(`${prefix}_result.json`, JSON.stringify(replaceBuffers(result), null, 2));
+  }
+}
+
+if (process.env.POML_TRACE) {
+  setTrace(true, process.env.POML_TRACE);
+}

--- a/python/poml/__init__.py
+++ b/python/poml/__init__.py
@@ -1,5 +1,5 @@
 from ._version import __version__
 
-from .api import poml
+from .api import poml, set_trace, clear_trace, get_trace
 from .cli import entrypoint, run
 from .prompt import Prompt

--- a/python/poml/api.py
+++ b/python/poml/api.py
@@ -1,8 +1,58 @@
 import json
 import os
 import tempfile
+import time
 from pathlib import Path
+from typing import Any, Dict, List, Optional
 from .cli import run
+
+_trace_enabled: bool = False
+_trace_log: List[Dict[str, Any]] = []
+_trace_dir: Optional[Path] = None
+
+
+def set_trace(enabled: bool = True, tempdir: Optional[str | Path] = None) -> Optional[Path]:
+    """Enable or disable tracing of ``poml`` calls.
+
+    If ``tempdir`` is provided when enabling tracing, a subdirectory named by
+    the current timestamp (in nanoseconds) is created inside ``tempdir``. The
+    resulting path is stored in the ``POML_TRACE`` environment variable so that
+    subprocesses share the same directory. The directory path is returned.
+    """
+
+    global _trace_enabled, _trace_dir
+    _trace_enabled = enabled
+
+    if not enabled:
+        _trace_dir = None
+        os.environ.pop("POML_TRACE", None)
+        return None
+
+    env_dir = os.environ.get("POML_TRACE")
+    if tempdir is not None:
+        base = Path(tempdir)
+        base.mkdir(parents=True, exist_ok=True)
+        run_dir = base / str(time.time_ns())
+        run_dir.mkdir(parents=True, exist_ok=True)
+        os.environ["POML_TRACE"] = str(run_dir)
+        _trace_dir = run_dir
+    elif env_dir:
+        run_dir = Path(env_dir)
+        run_dir.mkdir(parents=True, exist_ok=True)
+        _trace_dir = run_dir
+    else:
+        _trace_dir = None
+    return _trace_dir
+
+
+def clear_trace() -> None:
+    """Clear the collected trace log."""
+    _trace_log.clear()
+
+
+def get_trace() -> List[Dict[str, Any]]:
+    """Return a copy of the trace log."""
+    return list(_trace_log)
 
 
 def write_file(content: str):
@@ -12,12 +62,40 @@ def write_file(content: str):
     return temp_file
 
 
+
+
 def poml(
     markup: str | Path, context: dict | str | Path | None = None, stylesheet: dict | str | Path | None = None,
     chat: bool = True
 ) -> list | dict | str:
     temp_input_file = temp_context_file = temp_stylesheet_file = None
+    trace_record: Dict[str, Any] | None = None
     try:
+        if _trace_enabled:
+            trace_record = {}
+            if isinstance(markup, Path) or os.path.exists(str(markup)):
+                path = Path(markup)
+                trace_record["markup_path"] = str(path)
+                if path.exists():
+                    trace_record["markup"] = path.read_text()
+            else:
+                trace_record["markup"] = str(markup)
+
+            if isinstance(context, dict):
+                trace_record["context"] = json.dumps(context)
+            elif context:
+                if os.path.exists(str(context)):
+                    cpath = Path(context)
+                    trace_record["context_path"] = str(cpath)
+                    trace_record["context"] = cpath.read_text()
+            if isinstance(stylesheet, dict):
+                trace_record["stylesheet"] = json.dumps(stylesheet)
+            elif stylesheet:
+                if os.path.exists(str(stylesheet)):
+                    spath = Path(stylesheet)
+                    trace_record["stylesheet_path"] = str(spath)
+                    trace_record["stylesheet"] = spath.read_text()
+
         if isinstance(markup, Path):
             if not markup.exists():
                 raise FileNotFoundError(f"File not found: {markup}")
@@ -54,7 +132,10 @@ def poml(
 
             run(*args)
             output = output_file.read()
-            return json.loads(output)
+            result = json.loads(output)
+            if trace_record is not None:
+                trace_record["result"] = result
+            return result
     finally:
         if temp_input_file:
             temp_input_file.close()
@@ -62,3 +143,9 @@ def poml(
             temp_context_file.close()
         if temp_stylesheet_file:
             temp_stylesheet_file.close()
+        if trace_record is not None:
+            _trace_log.append(trace_record)
+
+
+if os.getenv("POML_TRACE") and not _trace_enabled:
+    set_trace(True)

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -1,4 +1,10 @@
-from poml import poml, Prompt
+import os
+import subprocess
+import sys
+from pathlib import Path
+import multiprocessing
+
+from poml import poml, Prompt, set_trace, clear_trace, get_trace
 
 
 def test_basic():
@@ -28,3 +34,50 @@ def test_prompt():
                 "content": "# My Task\n\nThis is a task description.\n\n## Subheading\n\nThis is a paragraph in the document.",
             }
         ]
+
+
+def test_trace():
+    clear_trace()
+    set_trace(True)
+    result = poml("<p>Trace Me</p>")
+    traces = get_trace()
+    set_trace(False)
+    assert result == [{"speaker": "human", "content": "Trace Me"}]
+    assert len(traces) == 1
+    assert "Trace Me" in traces[0]["markup"]
+
+
+def test_trace_directory(tmp_path: Path):
+    clear_trace()
+    run_dir = set_trace(True, tmp_path)
+    assert run_dir is not None
+    result = poml("<p>Dir</p>")
+    set_trace(False)
+    assert result == [{"speaker": "human", "content": "Dir"}]
+    files = list(run_dir.glob("*_markup.poml"))
+    assert len(files) == 1
+
+
+def _mp_worker():
+    poml("<p>MP</p>")
+
+
+def test_multiprocessing_trace(tmp_path: Path):
+    clear_trace()
+    run_dir = set_trace(True, tmp_path)
+    procs = [multiprocessing.Process(target=_mp_worker) for _ in range(3)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join()
+    set_trace(False)
+    assert len(list(run_dir.glob("*_markup.poml"))) == 3
+
+
+def test_envvar_autotrace(tmp_path: Path):
+    env = os.environ.copy()
+    trace_dir = tmp_path / "run"
+    env["POML_TRACE"] = str(trace_dir)
+    script = "from poml import poml; poml('<p>E</p>')"
+    subprocess.check_call([sys.executable, "-c", script], env=env)
+    assert any(f.name.endswith("_markup.poml") for f in trace_dir.iterdir())


### PR DESCRIPTION
## Summary
- serialize Buffers as base64 for trace dumps via `replaceBuffers`
- expose `dumpTrace` and utilities from the main package
- test Node tracing for binary buffers and document results

## Testing
- `npm install`
- `npm run build-cli`
- `npm test`
- `pip install nodejs-wheel`
- `PYTHONPATH=$PWD/python pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68590e138d2c832eaae953406af547b1