### PR TITLE
Fix jump to source feature

### DIFF
--- a/packages/poml-vscode-webview/index.ts
+++ b/packages/poml-vscode-webview/index.ts
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import { createPosterForVsCode } from './util';
 import { getState } from './state';
 import { setupToolbar } from './toolbar';
+import { getEditorLineNumberForPageOffset, offsetToLine } from './scrollSync';
 
 import throttle from 'lodash.throttle';
 
@@ -66,20 +67,27 @@ document.addEventListener('dblclick', event => {
     return;
   }
 
-  // FIXME: dblclick for switch to editor
+  for (let node = event.target as HTMLElement | null; node; node = node.parentElement) {
+    if (node.tagName === 'A') {
+      return;
+    }
 
-  // Ignore clicks on links
-  // for (let node = event.target as HTMLElement; node; node = node.parentNode as HTMLElement) {
-  //     if (node.tagName === 'A') {
-  //         return;
-  //     }
-  // }
+    const dataOffset = node.getAttribute('data-offset');
+    if (dataOffset) {
+      const offset = parseInt(dataOffset, 10);
+      if (!isNaN(offset)) {
+        const line = offsetToLine(offset, (state as any).rawText);
+        messaging.postMessage('didClick', { line });
+        return;
+      }
+    }
+  }
 
-  // const offset = event.pageY;
-  // const line = getEditorLineNumberForPageOffset(offset);
-  // if (typeof line === 'number' && !isNaN(line)) {
-  //     messaging.postMessage('didClick', { line: Math.floor(line) });
-  // }
+  const offset = event.pageY;
+  const line = getEditorLineNumberForPageOffset(offset);
+  if (typeof line === 'number' && !isNaN(line)) {
+    messaging.postMessage('didClick', { line: Math.floor(line) });
+  }
 });
 
 document.addEventListener('click', event => {

--- a/packages/poml-vscode-webview/scrollSync.ts
+++ b/packages/poml-vscode-webview/scrollSync.ts
@@ -123,6 +123,14 @@ export function getEditorLineNumberForPageOffset(offset: number) {
   return null;
 }
 
+export function offsetToLine(offset: number, text: string): number {
+  if (offset <= 0) {
+    return 0;
+  }
+  const before = text.slice(0, offset);
+  return before.split(/\r?\n/).length - 1;
+}
+
 /**
  * Useful for activating the selected elements.
  * Currently unused.

--- a/packages/poml-vscode-webview/tests/jumpToSource.test.ts
+++ b/packages/poml-vscode-webview/tests/jumpToSource.test.ts
@@ -1,0 +1,129 @@
+/** @jest-environment jsdom */
+
+import { describe, test, expect, jest } from '@jest/globals';
+(global as any).MessageChannel = require('worker_threads').MessageChannel;
+(global as any).TextEncoder = require('util').TextEncoder;
+(global as any).TextDecoder = require('util').TextDecoder;
+
+function setupWebview(html: string, vscode: any) {
+  document.documentElement.innerHTML = html;
+  (global as any).acquireVsCodeApi = () => vscode;
+  jest.resetModules();
+  require('../index');
+}
+
+describe('jump to source', () => {
+  test('double click posts didClick message', () => {
+    const raw = '<p><p speaker="ai">hello</p><p speaker="human">world</p></p>';
+    const ir = '<env presentation="markup" markup-lang="markdown" original-start-index="0" original-end-index="71"><p original-start-index="0" original-end-index="71"><p speaker="ai" original-start-index="3" original-end-index="34">hello</p><p speaker="human" original-start-index="35" original-end-index="67">world</p></p></env>';
+    const content = [
+      { speaker: 'ai', content: 'hello' },
+      { speaker: 'human', content: 'world' }
+    ];
+    const state = {
+      source: 'file.poml',
+      line: 0,
+      lineCount: raw.split(/\r?\n/).length,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: true,
+      speakerMode: true,
+      displayFormat: 'rendered',
+      rawText: raw,
+      ir,
+      content
+    };
+    const html = `<meta id="webview-state" data-state='${JSON.stringify(state)}'>
+    <div class="chat-message" data-offset="3">
+      <div class="chat-message-toolbar">
+        <a class="codicon codicon-code" role="button"></a>
+      </div>
+    </div>`;
+    const vscode = { postMessage: jest.fn(), setState: jest.fn() } as any;
+    setupWebview(html, vscode);
+
+    const msg = document.querySelector('.chat-message') as HTMLElement;
+    msg.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      type: 'didClick',
+      source: 'file.poml',
+      body: { line: 0 }
+    });
+  });
+
+  test('message button posts didClick message', () => {
+    const raw = '<p><p speaker="ai">hello</p><p speaker="human">world</p></p>';
+    const ir = '<env presentation="markup" markup-lang="markdown" original-start-index="0" original-end-index="71"><p original-start-index="0" original-end-index="71"><p speaker="ai" original-start-index="3" original-end-index="34">hello</p><p speaker="human" original-start-index="35" original-end-index="67">world</p></p></env>';
+    const content = [
+      { speaker: 'ai', content: 'hello' },
+      { speaker: 'human', content: 'world' }
+    ];
+    const state = {
+      source: 'file.poml',
+      line: 0,
+      lineCount: raw.split(/\r?\n/).length,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: true,
+      speakerMode: true,
+      displayFormat: 'rendered',
+      rawText: raw,
+      ir,
+      content
+    };
+    const html = `<meta id="webview-state" data-state='${JSON.stringify(state)}'>
+    <div class="chat-message" data-offset="3">
+      <div class="chat-message-toolbar">
+        <a class="codicon codicon-code" role="button"></a>
+      </div>
+    </div>`;
+    const vscode = { postMessage: jest.fn(), setState: jest.fn() } as any;
+    setupWebview(html, vscode);
+    const poster = require('../util').createPosterForVsCode(vscode);
+    const { setupToolbar } = require('../toolbar');
+    setupToolbar(vscode, poster);
+
+    (document.querySelector('.codicon-code') as HTMLElement).dispatchEvent(
+      new MouseEvent('click', { bubbles: true })
+    );
+
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      type: 'didClick',
+      source: 'file.poml',
+      body: { line: 0 }
+    });
+  });
+
+  test('double click plain text span posts didClick', () => {
+    const raw = '<p>hello <b>world</b></p>';
+    const ir = '<env presentation="markup" markup-lang="markdown" original-start-index="0" original-end-index="29"><p original-start-index="0" original-end-index="29">hello <b original-start-index="6" original-end-index="17">world</b></p></env>';
+    const state = {
+      source: 'file.poml',
+      line: 0,
+      lineCount: raw.split(/\r?\n/).length,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: true,
+      speakerMode: false,
+      displayFormat: 'plain',
+      rawText: raw,
+      ir,
+      content: 'hello **world**'
+    };
+    const html = `<meta id="webview-state" data-state='${JSON.stringify(state)}'>
+    <pre><code><span data-offset="0">hello </span><span data-offset="6">**world**</span></code></pre>`;
+    const vscode = { postMessage: jest.fn(), setState: jest.fn() } as any;
+    setupWebview(html, vscode);
+    const span = document.querySelector('span[data-offset="6"]') as HTMLElement;
+    span.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }));
+    expect(vscode.postMessage).toHaveBeenCalledWith({
+      type: 'didClick',
+      source: 'file.poml',
+      body: { line: 0 }
+    });
+  });
+});

--- a/packages/poml-vscode-webview/tests/scrollSync.test.ts
+++ b/packages/poml-vscode-webview/tests/scrollSync.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+import { jest, describe, test, expect, beforeEach } from '@jest/globals';
+
+const state = { lineCount: 3, scrollPreviewWithEditor: true };
+
+jest.mock('../state', () => ({
+  getState: () => state
+}));
+
+function setupDom() {
+  document.body.innerHTML = `
+    <div class="code-line" data-line="0"></div>
+    <div class="code-line" data-line="1"></div>
+    <div class="code-line" data-line="2"></div>
+  `;
+  const lines = Array.from(document.getElementsByClassName('code-line')) as HTMLElement[];
+  lines.forEach((el, idx) => {
+    (el as any).getBoundingClientRect = () => ({
+      top: idx * 20,
+      bottom: idx * 20 + 20,
+      left: 0,
+      right: 0,
+      height: 20,
+      width: 100,
+      x: 0,
+      y: idx * 20,
+      toJSON() { }
+    } as DOMRect);
+  });
+}
+
+beforeEach(() => {
+  jest.resetModules();
+  setupDom();
+  Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+});
+
+describe('scrollSync', () => {
+  test('getEditorLineNumberForPageOffset maps offsets to lines', () => {
+    const { getEditorLineNumberForPageOffset } = require('../scrollSync');
+    expect(getEditorLineNumberForPageOffset(10)).toBeCloseTo(0.5);
+    expect(getEditorLineNumberForPageOffset(30)).toBeCloseTo(1.5);
+    expect(getEditorLineNumberForPageOffset(70)).toBe(2);
+    Object.defineProperty(window, 'scrollY', { value: 10, writable: true });
+    expect(getEditorLineNumberForPageOffset(40)).toBeCloseTo(1.5);
+  });
+
+  test('offsetToLine converts offsets', () => {
+    const { offsetToLine } = require('../scrollSync');
+    const text = 'a\nb\nc';
+    expect(offsetToLine(0, text)).toBe(0);
+    expect(offsetToLine(2, text)).toBe(1);
+    expect(offsetToLine(4, text)).toBe(2);
+  });
+
+  test('scrollToRevealSourceLine scrolls to element', () => {
+    const { scrollToRevealSourceLine } = require('../scrollSync');
+    const spy = jest.spyOn(window, 'scroll').mockImplementation(() => {});
+    scrollToRevealSourceLine(1);
+    expect(spy).toHaveBeenCalledWith(0, 20);
+    spy.mockRestore();
+  });
+});

--- a/packages/poml-vscode/lsp/server.ts
+++ b/packages/poml-vscode/lsp/server.ts
@@ -40,6 +40,7 @@ import { readdirSync, readFileSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { PreviewParams, PreviewMethodName, PreviewResponse } from '../panel/types';
 import { formatComponentDocumentation, formatParameterDocumentation } from './documentFormatter';
+import { computeMessageOffsets, computePlainSpans } from '../util/sourceMap';
 import {
   DelayedTelemetryReporter,
   TelemetryEvent,
@@ -227,6 +228,8 @@ class PomlLspServer {
       rawText: documentContent,
       ir,
       content: result,
+      messageOffsets: computeMessageOffsets(ir),
+      plainSpans: computePlainSpans(ir),
       error: params.returnAllErrors
         ? ErrorCollection.list()
         : ErrorCollection.empty()

--- a/packages/poml-vscode/lsp/server.ts
+++ b/packages/poml-vscode/lsp/server.ts
@@ -59,7 +59,7 @@ interface DiagnosticCache {
   diagnostics: Diagnostic[];
 }
 
-class PomlLspServer {
+export class PomlLspServer {
   // Create a connection for the server, using Node's IPC as a transport.
   // Also include all preview / proposed LSP features.
   private readonly connection;
@@ -164,7 +164,7 @@ class PomlLspServer {
     }
   }
 
-  private async computePreviewResponse(params: PreviewParams): Promise<PreviewResponse> {
+  public async computePreviewResponse(params: PreviewParams): Promise<PreviewResponse> {
     const { speakerMode, uri } = params;
 
     const filePath = fileURLToPath(uri);
@@ -613,5 +613,7 @@ class PomlLspServer {
   }
 }
 
-const lspServer = new PomlLspServer();
-lspServer.listen();
+if (require.main === module) {
+  const lspServer = new PomlLspServer();
+  lspServer.listen();
+}

--- a/packages/poml-vscode/panel/types.ts
+++ b/packages/poml-vscode/panel/types.ts
@@ -57,6 +57,14 @@ export interface PreviewResponse {
   rawText: string;
   ir: string;
   content: RichContent | Message[];
+  /**
+   * For chat messages, the original start index of each message in the source file.
+   */
+  messageOffsets?: number[];
+  /**
+   * For plain text preview, mapping of spans to their source offsets.
+   */
+  plainSpans?: { text: string; offset: number }[];
   error?: string | any[];
 }
 

--- a/packages/poml-vscode/tests/lsp.test.ts
+++ b/packages/poml-vscode/tests/lsp.test.ts
@@ -1,0 +1,19 @@
+import * as assert from 'assert';
+import { PomlLspServer } from '../lsp/server';
+import { PreviewParams } from '../panel/types';
+
+suite('Language Server', () => {
+  test('computePreviewResponse includes mappings', async () => {
+    const server = new PomlLspServer();
+    const raw = '<p><p speaker="ai">hello</p><p speaker="human">world</p></p>';
+    const params: PreviewParams = {
+      uri: 'file:///test.poml',
+      text: raw,
+      speakerMode: true,
+      displayFormat: 'rendered'
+    } as any;
+    const res = await server.computePreviewResponse(params);
+    assert.deepStrictEqual(res.messageOffsets, [3, 35]);
+    assert.ok(Array.isArray(res.plainSpans) && res.plainSpans.length > 0);
+  });
+});

--- a/packages/poml-vscode/tests/panelContent.test.ts
+++ b/packages/poml-vscode/tests/panelContent.test.ts
@@ -1,8 +1,13 @@
 import * as assert from 'assert';
+import cheerio from 'cheerio';
+import { read } from 'poml';
+import { computeMessageOffsets, computePlainSpans } from '../util/sourceMap';
 import { pomlVscodePanelContent } from '../panel/content';
 
 suite('Panel content helper', () => {
-  test('basic rendering works', () => {
+  test('basic rendering works', async () => {
+    const raw = '<p>test</p>';
+    const ir = await read(raw);
     const html = pomlVscodePanelContent({
       source: 'source',
       line: 0,
@@ -13,12 +18,94 @@ suite('Panel content helper', () => {
       doubleClickToSwitchToEditor: false,
       speakerMode: true,
       displayFormat: 'rendered',
-      rawText: '<p>test</p>',
-      ir: '',
+      rawText: raw,
+      ir,
       content: [],
       extensionResourcePath: (p: string) => p,
       localResourcePath: (p: string) => p,
     });
     assert.ok(html.includes('test'));
+  });
+
+  test('webview state contains source mappings', async () => {
+    const raw = '<p>test</p>';
+    const ir = await read(raw);
+    const content: any[] = [];
+    const html = pomlVscodePanelContent({
+      source: 'file.poml',
+      line: 0,
+      lineCount: 1,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: false,
+      speakerMode: true,
+      displayFormat: 'rendered',
+      rawText: raw,
+      ir,
+      content: content as any,
+      extensionResourcePath: (p: string) => p,
+      localResourcePath: (p: string) => p,
+    });
+    const $ = cheerio.load(html);
+    const state = JSON.parse($('#webview-state').attr('data-state')!);
+    assert.ok(state.ir.includes('original-start-index'));
+  });
+
+  test('chat messages have data-offset attributes', async () => {
+    const raw = '<p><p speaker="ai">hello</p><p speaker="human">world</p></p>';
+    const ir = await read(raw);
+    const content = [
+      { speaker: 'ai', content: 'hello' },
+      { speaker: 'human', content: 'world' }
+    ];
+    const offsets = computeMessageOffsets(ir);
+    const html = pomlVscodePanelContent({
+      source: 'file.poml',
+      line: 0,
+      lineCount: raw.split(/\r?\n/).length,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: false,
+      speakerMode: true,
+      displayFormat: 'rendered',
+      rawText: raw,
+      ir,
+      content: content as any,
+      messageOffsets: offsets,
+      extensionResourcePath: (p: string) => p,
+      localResourcePath: (p: string) => p,
+    });
+    const $ = cheerio.load(html);
+    const domOffsets = $('.chat-message').map((_: any, el: any) => $(el).attr('data-offset')).get();
+    assert.deepStrictEqual(domOffsets.map(Number), [3, 35]);
+  });
+
+  test('plain text spans have data-offset attributes', async () => {
+    const raw = '<p>hello <b>world</b></p>';
+    const ir = await read(raw);
+    const spansData = computePlainSpans(ir);
+    const html = pomlVscodePanelContent({
+      source: 'file.poml',
+      line: 0,
+      lineCount: raw.split(/\r?\n/).length,
+      locked: false,
+      scrollPreviewWithEditor: false,
+      scrollEditorWithPreview: false,
+      doubleClickToSwitchToEditor: false,
+      speakerMode: false,
+      displayFormat: 'plain',
+      rawText: raw,
+      ir,
+      content: 'hello **world**',
+      plainSpans: spansData,
+      extensionResourcePath: (p: string) => p,
+      localResourcePath: (p: string) => p,
+    });
+    const $ = cheerio.load(html);
+    const spans = $('pre code span');
+    const offsets = spans.map((_: any, el: any) => $(el).attr('data-offset')).get();
+    assert.deepStrictEqual(offsets.map(Number), [0, 6]);
   });
 });

--- a/packages/poml-vscode/util/sourceMap.ts
+++ b/packages/poml-vscode/util/sourceMap.ts
@@ -1,0 +1,45 @@
+import cheerio from 'cheerio';
+import { EnvironmentDispatcher } from 'poml/writer';
+
+export interface PlainSpan {
+  text: string;
+  offset: number;
+}
+
+export function computeMessageOffsets(ir: string): number[] {
+  const $ = cheerio.load(ir, { xml: { xmlMode: true } });
+  return $('[speaker]')
+    .map((_, el) => parseInt($(el).attr('original-start-index') || '0', 10))
+    .get();
+}
+
+export function computePlainSpans(ir: string): PlainSpan[] {
+  const writer = new EnvironmentDispatcher();
+  const result = writer.writeWithSourceMap(ir) as any;
+  const output: string = result.output;
+  const mappings: { inputStart: number; inputEnd: number; outputStart: number; outputEnd: number; }[] = result.mappings;
+  const root = mappings.find(m => m.outputStart === 0 && m.outputEnd === output.length - 1) || mappings[0];
+  const spans: PlainSpan[] = [];
+  const sorted = mappings
+    .filter(m => m !== root)
+    .sort((a: { outputStart: number }, b: { outputStart: number }) => a.outputStart - b.outputStart);
+  let pos = 0;
+  const rootOffset = root.inputStart - root.outputStart;
+  const pushSpan = (start: number, end: number, offset: number) => {
+    if (end <= start) {
+      return;
+    }
+    spans.push({ text: output.slice(start, end), offset });
+  };
+  for (const m of sorted as { inputStart: number; outputStart: number; outputEnd: number }[]) {
+    if (pos < m.outputStart) {
+      pushSpan(pos, m.outputStart, pos + rootOffset);
+    }
+    pushSpan(m.outputStart, m.outputEnd + 1, m.inputStart);
+    pos = m.outputEnd + 1;
+  }
+  if (pos < output.length) {
+    pushSpan(pos, output.length, pos + rootOffset);
+  }
+  return spans;
+}


### PR DESCRIPTION
## Summary
- compute message and plain text offsets in LSP server
- expose offsets via `PreviewResponse`
- adjust panel HTML to read offset arrays instead of recomputing
- create `sourceMap` helper
- update panel content tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68590d315a2c832ea62466484e8689dd