### PR TITLE
Add Codex setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Contributor Guide
+
+This repository contains a TypeScript/JavaScript project together with a small Python package.
+Follow these instructions when using Codex or contributing changes.
+
+## Environment Setup
+- **Node.js**: version 22.x
+- **Python**: version 3.11
+
+Run `bash setup.sh` from the repository root to install all dependencies.
+
+## Testing Instructions
+After your changes you must verify that everything still builds and tests pass.
+Execute the following commands from the repository root:
+
+```bash
+npm run build-webview
+npm run build-cli
+npm run lint
+npm test
+python -m pytest python/tests
+```
+
+Optional VS Code extension tests can be run with:
+
+```bash
+npm run compile && npm run test-vscode
+```
+
+## PR Instructions
+Use the title format `[POML] <Your summary>` when opening pull requests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,26 @@
-# Contributor Guide
+# Agent Contributor Guide
 
-This repository contains a TypeScript/JavaScript project together with a small Python package.
-Follow these instructions when using Codex or contributing changes.
+This repository contains a TypeScript/JavaScript project together with a lite Python SDK.
+These instructions are for agents like Codex to contribute changes.
+
+## Repository Structure
+- **packages/poml** – Core TypeScript package of POML parsing and rendering.
+- **packages/poml-vscode** – VS Code Extension package of POML.
+- **packages/poml-vscode-webview** – The VS Code Webview frontend JS/TS code.
+- **python/** – Python SDK and CLI implementation.
+- **examples/** – Sample POML files.
+- **docs/** – Project documentation.
 
 ## Environment Setup
-- **Node.js**: version 22.x
-- **Python**: version 3.11
+- **Node.js**: version 22.x (20.x should also work)
+- **Python**: version 3.11 (3.10 or 3.12 should also work)
 
-Run `bash setup.sh` from the repository root to install all dependencies.
+```bash
+npm ci
+npm run build-webview
+npm run build-cli
+python -m pip install -e .[dev]
+```
 
 ## Testing Instructions
 After your changes you must verify that everything still builds and tests pass.
@@ -21,11 +34,17 @@ npm test
 python -m pytest python/tests
 ```
 
-Optional VS Code extension tests can be run with:
+If you have updated the VS Code extension, please run the extension tests with:
 
 ```bash
-npm run compile && npm run test-vscode
+xvfb-run -a npm run compile && xvfb-run -a npm run test-vscode
+```
+
+Update the component specifications if you have updated the type annotations and documentations of the components.
+
+```bash
+npm run generate-component-spec
 ```
 
 ## PR Instructions
-Use the title format `[POML] <Your summary>` when opening pull requests.
+Use clear titles and summaries. Include relevant references to documentation when modifying or adding features.

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-npm ci
-python -m pip install -e .[dev]
-npm run build-webview
-npm run build-cli
-

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm ci
+python -m pip install -e .[dev]
+npm run build-webview
+npm run build-cli
+


### PR DESCRIPTION
## Summary
- add contributor guide to help Codex run tests
- provide setup.sh script for environment configuration

## Testing
- `bash setup.sh`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_686247a82ea0832eafe567984ed45f0c