### PR TITLE
Fix whitespace between images in example

### DIFF
--- a/examples/expects/104_financial_analysis.txt
+++ b/examples/expects/104_financial_analysis.txt
@@ -81,8 +81,6 @@ The following two charts on a visualization of the table above. One of them show
 
 {"type":"image/png","base64":"iVBORw0KGgoAAAANSUhEUgAABxUAAAVWCAYAAABb2OdwAAAACXBIWXMAADLAAAAywAEoZF...
 
- 
-
 {"type":"image/png","base64":"iVBORw0KGgoAAAANSUhEUgAABxUAAAVWCAYAAABb2OdwAAAACXBIWXMAADLAAAAywAEoZF...
 
 **Hint:**  The table contains stock tickers of 7 companies. Please analyze and give financial analysis and comparison for them.


### PR DESCRIPTION
## Summary
- keep only one newline between images in `104_financial_analysis.txt`
- remove whitespace between sequential multimedia nodes in `MarkdownWriter`
- document the new whitespace logic

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_686379e79f90832eb96dcfa9550070c3