### PR TITLE
Add POML chat participant

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onWebviewPanel:poml.preview"
+    "onWebviewPanel:poml.preview",
+    "onChatParticipant:poml.runner"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -112,9 +113,17 @@
         }
       },
       {
-        "command": "poml.telemetry.completion",
-        "title": "Telemetry: Completion",
-        "category": "POML"
+      "command": "poml.telemetry.completion",
+      "title": "Telemetry: Completion",
+      "category": "POML"
+      }
+    ],
+    "chatParticipants": [
+      {
+        "id": "poml.runner",
+        "fullName": "POML",
+        "name": "poml",
+        "description": "Run a POML chat"
       }
     ],
     "menus": {

--- a/packages/poml-vscode/chat/pomlParticipant.ts
+++ b/packages/poml-vscode/chat/pomlParticipant.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+import { getClient } from 'poml-vscode/extension';
+import { PreviewMethodName, PreviewParams, PreviewResponse } from 'poml-vscode/panel/types';
+import { Message } from 'poml';
+
+export function registerPomlChatParticipant(context: vscode.ExtensionContext) {
+  const handler: vscode.ChatRequestHandler = async (
+    request: vscode.ChatRequest,
+    _chatContext: vscode.ChatContext,
+    stream: vscode.ChatResponseStream,
+    token: vscode.CancellationToken
+  ): Promise<vscode.ChatResult | void> => {
+    const files = request.references
+      .map(ref => ref.value)
+      .map(v => (v instanceof vscode.Location ? v.uri : v))
+      .filter((v): v is vscode.Uri => v instanceof vscode.Uri);
+
+    const docs = files.map(f => `  <document src="${f.toString()}" parser="txt" />`).join('\n');
+    const markup = `<poml>\n  <task>${request.prompt}</task>\n  <cp caption="References">\n${docs}\n  </cp>\n</poml>`;
+
+    const params: PreviewParams = {
+      uri: 'inmemory://poml/chat.poml',
+      text: markup,
+      speakerMode: true,
+      displayFormat: 'rendered'
+    };
+    const response: PreviewResponse = await getClient().sendRequest(PreviewMethodName, params);
+    if (response.error) {
+      stream.markdown(`Error rendering POML: ${response.error}`);
+      return;
+    }
+    const messages = response.content as Message[];
+    const chatMessages = messages.map(m => {
+      const text = typeof m.content === 'string' ? m.content : JSON.stringify(m.content);
+      return m.speaker === 'human'
+        ? vscode.LanguageModelChatMessage.User(text)
+        : vscode.LanguageModelChatMessage.Assistant(text);
+    });
+
+    const [model] = await vscode.lm.selectChatModels();
+    if (!model) {
+      stream.markdown('No chat model available.');
+      return;
+    }
+    const chatResponse = await model.sendRequest(chatMessages, {}, token);
+    for await (const part of chatResponse.text) {
+      stream.markdown(part);
+    }
+    return {};
+  };
+
+  const participant = vscode.chat.createChatParticipant('poml.runner', handler);
+  participant.iconPath = vscode.Uri.joinPath(context.extensionUri, 'media/icon/poml-icon-16.svg');
+  context.subscriptions.push(participant);
+}

--- a/packages/poml-vscode/extension.ts
+++ b/packages/poml-vscode/extension.ts
@@ -14,6 +14,7 @@ import {
 } from 'vscode-languageclient/node';
 import { initializeReporter, getTelemetryReporter, TelemetryClient } from './util/telemetryClient';
 import { TelemetryEvent } from './util/telemetryServer';
+import { registerPomlChatParticipant } from './chat/pomlParticipant';
 
 let extensionPath = "";
 
@@ -40,6 +41,8 @@ export function activate(context: vscode.ExtensionContext) {
   commandManager.register(new command.ShowPreviewToSideCommand(webviewManager));
   commandManager.register(new command.ShowLockedPreviewToSideCommand(webviewManager));
   commandManager.register(new command.ShowSourceCommand(webviewManager));
+
+  registerPomlChatParticipant(context);
   
   const connectionString = getConnectionString();
   if (connectionString) {


### PR DESCRIPTION
## Summary
- register a new POML chat participant for VS Code
- integrate registration in extension activation
- expose chat participant details in `package.json`

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_68637dd13bdc832eabc6c5e7215e8b9b