### PR TITLE
Fix extra spaces after captions

### DIFF
--- a/examples/expects/104_financial_analysis.txt
+++ b/examples/expects/104_financial_analysis.txt
@@ -83,4 +83,4 @@ The following two charts on a visualization of the table above. One of them show
 
 {"type":"image/png","base64":"iVBORw0KGgoAAAANSUhEUgAABxUAAAVWCAYAAABb2OdwAAAACXBIWXMAADLAAAAywAEoZF...
 
-**Hint:**  The table contains stock tickers of 7 companies. Please analyze and give financial analysis and comparison for them.
+**Hint:** The table contains stock tickers of 7 companies. Please analyze and give financial analysis and comparison for them.

--- a/examples/expects/201_orders_qa.txt
+++ b/examples/expects/201_orders_qa.txt
@@ -41,4 +41,4 @@ Instruction 5: Answer in plain English and no sources are required.
 
 **QUESTION:** How much did I pay for my last order?
 
-**Answer:** 
+**Answer:**

--- a/packages/poml/components/instructions.tsx
+++ b/packages/poml/components/instructions.tsx
@@ -537,7 +537,7 @@ export const Question = component('Question', ['qa'])((
         {children}
       </CaptionedParagraph>
       {answerCaption && presentation === 'markup' ? (
-        <Caption caption={answerCaption} captionStyle={captionStyle} {...others} />
+        <Caption caption={answerCaption} captionStyle={captionStyle} captionTailingSpace={false} {...others} />
       ) : null}
     </Paragraph>
   );

--- a/packages/poml/components/utils.tsx
+++ b/packages/poml/components/utils.tsx
@@ -200,10 +200,22 @@ export const CaptionedParagraph = component('CaptionedParagraph', {
         </Paragraph>
       );
     } else if (captionStyle === 'bold' || captionStyle === 'plain') {
+      let newChildren = children as any;
+      const firstChild = Array.isArray(children) ? children[0] : children;
+      if (typeof firstChild === 'string') {
+        const trimmed = firstChild.replace(/^\s+/, '');
+        if (trimmed !== firstChild) {
+          if (Array.isArray(children)) {
+            newChildren = [trimmed, ...children.slice(1)];
+          } else {
+            newChildren = trimmed;
+          }
+        }
+      }
       return (
         <Paragraph {...others}>
           <Caption captionStyle={captionStyle} {...others} />
-          {children}
+          {newChildren}
         </Paragraph>
       );
     } else if (captionStyle === 'hidden') {

--- a/packages/poml/tests/table.test.tsx
+++ b/packages/poml/tests/table.test.tsx
@@ -310,7 +310,7 @@ describe('table', () => {
         '\n' +
         '**Question:** How many calories are in Cupcake?\n' +
         '\n' +
-        '**Answer:** '
+        '**Answer:**'
     );
   });
 


### PR DESCRIPTION
## Summary
- trim leading whitespace in CaptionedParagraph
- avoid trailing space for Answer caption
- update expectations and table test

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_6863a3b2cf60832e9b63e9859beaaa67