### PR TITLE
Fix trailing spaces in generated captions

### DIFF
--- a/examples/expects/104_financial_analysis.txt
+++ b/examples/expects/104_financial_analysis.txt
@@ -83,4 +83,4 @@ The following two charts on a visualization of the table above. One of them show
 
 {"type":"image/png","base64":"iVBORw0KGgoAAAANSUhEUgAABxUAAAVWCAYAAABb2OdwAAAACXBIWXMAADLAAAAywAEoZF...
 
-**Hint:**  The table contains stock tickers of 7 companies. Please analyze and give financial analysis and comparison for them.
+**Hint:** The table contains stock tickers of 7 companies. Please analyze and give financial analysis and comparison for them.

--- a/examples/expects/201_orders_qa.txt
+++ b/examples/expects/201_orders_qa.txt
@@ -41,4 +41,4 @@ Instruction 5: Answer in plain English and no sources are required.
 
 **QUESTION:** How much did I pay for my last order?
 
-**Answer:** 
+**Answer:**

--- a/packages/poml/components/instructions.tsx
+++ b/packages/poml/components/instructions.tsx
@@ -537,7 +537,12 @@ export const Question = component('Question', ['qa'])((
         {children}
       </CaptionedParagraph>
       {answerCaption && presentation === 'markup' ? (
-        <Caption caption={answerCaption} captionStyle={captionStyle} {...others} />
+        <Caption
+          caption={answerCaption}
+          captionStyle={captionStyle}
+          captionTailingSpace={false}
+          {...others}
+        />
       ) : null}
     </Paragraph>
   );

--- a/packages/poml/components/utils.tsx
+++ b/packages/poml/components/utils.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { component, ReadError } from 'poml/base';
+import { component, ReadError, trimChildrenWhiteSpace } from 'poml/base';
 import {
   PropsSyntaxAny,
   Text,
@@ -192,22 +192,24 @@ export const CaptionedParagraph = component('CaptionedParagraph', {
   const presentation = computeSyntaxContext(props);
   if (presentation === 'markup') {
     const { captionStyle = 'header', children, ...others } = props;
+    const trimmedChildren = trimChildrenWhiteSpace(children, props);
+    const hasContent = React.Children.count(trimmedChildren) > 0;
     if (captionStyle === 'header') {
       return (
         <Paragraph {...others}>
-          <Caption captionStyle={captionStyle} {...others} />
-          <SubContent>{children}</SubContent>
+          <Caption captionStyle={captionStyle} captionTailingSpace={hasContent} {...others} />
+          <SubContent>{trimmedChildren}</SubContent>
         </Paragraph>
       );
     } else if (captionStyle === 'bold' || captionStyle === 'plain') {
       return (
         <Paragraph {...others}>
-          <Caption captionStyle={captionStyle} {...others} />
-          {children}
+          <Caption captionStyle={captionStyle} captionTailingSpace={hasContent} {...others} />
+          {trimmedChildren}
         </Paragraph>
       );
     } else if (captionStyle === 'hidden') {
-      return <Paragraph {...others}>{children}</Paragraph>;
+      return <Paragraph {...others}>{trimmedChildren}</Paragraph>;
     } else {
       throw ReadError.fromProps(`Unsupported caption style: ${captionStyle}`, props);
     }

--- a/packages/poml/tests/table.test.tsx
+++ b/packages/poml/tests/table.test.tsx
@@ -310,7 +310,7 @@ describe('table', () => {
         '\n' +
         '**Question:** How many calories are in Cupcake?\n' +
         '\n' +
-        '**Answer:** '
+        '**Answer:**'
     );
   });
 


### PR DESCRIPTION
## Summary
- trim children when building captioned paragraphs and adjust trailing space logic
- disable trailing space for empty answers
- update expected outputs for financial analysis and orders QA examples
- fix test expectations for table QA output

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_6863a3b2cf60832e9b63e9859beaaa67