### PR TITLE
Improve trace directory naming

### DIFF
--- a/python/poml/api.py
+++ b/python/poml/api.py
@@ -1,7 +1,6 @@
 import json
 import os
 import tempfile
-import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional

--- a/python/poml/api.py
+++ b/python/poml/api.py
@@ -2,6 +2,7 @@ import json
 import os
 import tempfile
 import time
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 from .cli import run
@@ -15,7 +16,7 @@ def set_trace(enabled: bool = True, tempdir: Optional[str | Path] = None) -> Opt
     """Enable or disable tracing of ``poml`` calls.
 
     If ``tempdir`` is provided when enabling tracing, a subdirectory named by
-    the current timestamp (in nanoseconds) is created inside ``tempdir``. The
+    the current timestamp (``YYYYMMDDHHMMSSffffff``) is created inside ``tempdir``. The
     returned directory may be shared with subprocesses by setting the
     ``POML_TRACE`` environment variable in the invoking script.
     """
@@ -31,7 +32,8 @@ def set_trace(enabled: bool = True, tempdir: Optional[str | Path] = None) -> Opt
     if tempdir is not None:
         base = Path(tempdir)
         base.mkdir(parents=True, exist_ok=True)
-        run_dir = base / str(time.time_ns())
+        ts = datetime.now().strftime("%Y%m%d%H%M%S%f")
+        run_dir = base / ts
         run_dir.mkdir(parents=True, exist_ok=True)
         _trace_dir = run_dir
     elif env_dir:

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import re
 from pathlib import Path
 import multiprocessing
 
@@ -100,6 +101,14 @@ def test_trace_directory(tmp_path: Path):
     assert result == [{"speaker": "human", "content": "Dir"}]
     files = list(run_dir.glob("*_markup.poml"))
     assert len(files) == 1
+
+
+def test_trace_directory_name_format(tmp_path: Path):
+    clear_trace()
+    run_dir = set_trace(True, tmp_path)
+    assert run_dir is not None
+    assert re.fullmatch(r"\d{20}", run_dir.name)
+    set_trace(False)
 
 
 def _mp_worker():


### PR DESCRIPTION
## Summary
- use a human-readable timestamp format for Python trace directories
- verify trace directory names are 20-digit timestamps

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pip install -e .[dev]`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_686ceafcb96c832e9aa17ac3f6e15046