### PR TITLE
Add token counts to webview display

### DIFF
--- a/media/style.css
+++ b/media/style.css
@@ -9,6 +9,7 @@ body {
   --poml-font-family: var(--vscode-font-family);
   --poml-font-size: var(--vscode-editor-font-size);
   --poml-font-size-08: calc(var(--vscode-editor-font-size) * 0.8);
+  --poml-font-size-09: calc(var(--vscode-editor-font-size) * 0.9);
   --poml-font-size-12: calc(var(--vscode-editor-font-size) * 1.2);
   --poml-font-size-15: calc(var(--vscode-editor-font-size) * 1.5);
   --poml-font-size-20: calc(var(--vscode-editor-font-size) * 2);
@@ -302,9 +303,9 @@ pre code {
 }
 
 .chat-message-header .content .name .token-count {
-  margin-left: var(--poml-padding-05);
+  margin-left: var(--poml-padding);
   font-weight: normal;
-  font-size: var(--poml-font-size-08);
+  font-size: var(--poml-font-size-09);
   color: var(--vscode-descriptionForeground);
 }
 
@@ -377,9 +378,7 @@ pre code {
 }
 
 .token-total {
-  margin-top: var(--poml-padding);
   text-align: right;
-  font-size: var(--poml-font-size-08);
-  font-style: italic;
+  font-size: var(--poml-font-size-09);
   color: var(--vscode-descriptionForeground);
 }

--- a/media/style.css
+++ b/media/style.css
@@ -301,6 +301,13 @@ pre code {
   margin: 0;
 }
 
+.chat-message-header .content .name .token-count {
+  margin-left: var(--poml-padding-05);
+  font-weight: normal;
+  font-size: var(--poml-font-size-08);
+  color: var(--vscode-descriptionForeground);
+}
+
 .chat-message-toolbar {
   position: absolute;
   right: 0;
@@ -367,4 +374,12 @@ pre code {
 
 .chat-message-content {
   padding: 0 var(--poml-padding-02);
+}
+
+.token-total {
+  margin-top: var(--poml-padding);
+  text-align: right;
+  font-size: var(--poml-font-size-08);
+  font-style: italic;
+  color: var(--vscode-descriptionForeground);
 }

--- a/media/style.css
+++ b/media/style.css
@@ -302,7 +302,7 @@ pre code {
   margin: 0;
 }
 
-.chat-message-header .content .name .token-count {
+.chat-message-header .token-count {
   margin-left: var(--poml-padding);
   font-weight: normal;
   font-size: var(--poml-font-size-09);

--- a/packages/poml-vscode/panel/content.tsx
+++ b/packages/poml-vscode/panel/content.tsx
@@ -156,8 +156,14 @@ function Markdown(props: { content: RichContent }) {
   return <div dangerouslySetInnerHTML={{ __html: converter.makeHtml(concatenatedMarkdown) }} />;
 }
 
-function ChatMessages(props: { messages: Message[]; toRender: boolean; mappings?: SourceMapMessage[]; rawText?: string }) {
-  const { messages, toRender, mappings, rawText } = props;
+function ChatMessages(props: {
+  messages: Message[];
+  toRender: boolean;
+  tokens?: number[];
+  mappings?: SourceMapMessage[];
+  rawText?: string;
+}) {
+  const { messages, toRender, tokens, mappings, rawText } = props;
   return messages.map((message, idx) => {
     const map = mappings ? mappings[idx] : undefined;
     const line = map && rawText !== undefined ? lineFromIndex(rawText, map.startIndex) : undefined;
@@ -180,7 +186,12 @@ function ChatMessages(props: { messages: Message[]; toRender: boolean; mappings?
             <div className="avatar">
               <div className={`codicon codicon-${icon}`}></div>
             </div>
-            <h3 className="name">{role}</h3>
+            <h3 className="name">
+              {role}
+              {tokens && tokens[idx] !== undefined && (
+                <span className="token-count">{tokens[idx]}</span>
+              )}
+            </h3>
           </div>
           <div className="chat-message-toolbar">
             <div className="toolbar-item tooltip-anchor">
@@ -220,7 +231,7 @@ function ChatMessages(props: { messages: Message[]; toRender: boolean; mappings?
 }
 
 function Content(props: WebviewUserOptions & PreviewResponse) {
-  let { displayFormat, ir, content, sourceMap, rawText } = props;
+  let { displayFormat, ir, content, sourceMap, rawText, tokens } = props;
 
   let toCopy: string =
     typeof content === 'string'
@@ -233,10 +244,16 @@ function Content(props: WebviewUserOptions & PreviewResponse) {
       result = <CodeBlock content={ir} />;
     } else if (displayFormat === 'plain') {
       result = (
-        <ChatMessages messages={content} toRender={false} mappings={sourceMap as SourceMapMessage[]} rawText={rawText} />
+        <ChatMessages
+          messages={content}
+          toRender={false}
+          tokens={tokens?.perMessage}
+          mappings={sourceMap as SourceMapMessage[]}
+          rawText={rawText}
+        />
       );
     } else if (displayFormat === 'rendered') {
-      result = <ChatMessages messages={content} toRender={true} />;
+      result = <ChatMessages messages={content} toRender={true} tokens={tokens?.perMessage} />;
     } else {
       result = <div>Invalid display format</div>;
     }
@@ -257,6 +274,9 @@ function Content(props: WebviewUserOptions & PreviewResponse) {
     <div className="main" id="content">
       <div className="hidden" id="copy-content" data-value={toCopy} />
       {result}
+      {tokens && (
+        <div className="token-total">Total tokens: {tokens.total}</div>
+      )}
     </div>
   );
 }

--- a/packages/poml-vscode/panel/content.tsx
+++ b/packages/poml-vscode/panel/content.tsx
@@ -164,7 +164,7 @@ function ChatMessages(props: {
   rawText?: string;
 }) {
   const { messages, toRender, tokens, mappings, rawText } = props;
-  return messages.map((message, idx) => {
+  const chatMessages = messages.map((message, idx) => {
     const map = mappings ? mappings[idx] : undefined;
     const line = map && rawText !== undefined ? lineFromIndex(rawText, map.startIndex) : undefined;
     let role: string = message.speaker;
@@ -189,7 +189,7 @@ function ChatMessages(props: {
             <h3 className="name">
               {role}
               {tokens && tokens[idx] !== undefined && (
-                <span className="token-count">{tokens[idx]}</span>
+                <span className="token-count">{tokens[idx]} tokens</span>
               )}
             </h3>
           </div>
@@ -228,6 +228,7 @@ function ChatMessages(props: {
       </div>
     );
   });
+  return <div className="chat-messages">{chatMessages}</div>;
 }
 
 function Content(props: WebviewUserOptions & PreviewResponse) {


### PR DESCRIPTION
## Summary
- show token counts per chat message and total at bottom
- style token counters in content.tsx
- update CSS styling for token count display

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`
- `npm run generate-component-spec`


------
https://chatgpt.com/codex/tasks/task_e_686e406d2a44832e859df55c19a499f9