### PR TITLE
Add prompt gallery to extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,23 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "pomlGallery",
+          "title": "POML",
+          "icon": "./media/icon/poml-icon-16.svg"
+        }
+      ]
+    },
+    "views": {
+      "pomlGallery": [
+        {
+          "id": "pomlPromptGallery",
+          "name": "Prompt Gallery"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "poml",
@@ -137,6 +154,22 @@
         "title": "Telemetry: Completion",
         "category": "POML"
       }
+      ,
+      {
+        "command": "poml.gallery.addPrompt",
+        "title": "Add Prompt",
+        "category": "POML"
+      },
+      {
+        "command": "poml.gallery.deletePrompt",
+        "title": "Delete Prompt",
+        "category": "POML"
+      },
+      {
+        "command": "poml.gallery.editPrompt",
+        "title": "Edit Prompt",
+        "category": "POML"
+      }
     ],
     "chatParticipants": [
       {
@@ -158,6 +191,25 @@
           "command": "poml.showSource",
           "when": "pomlPreviewFocus",
           "group": "navigation"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "poml.gallery.addPrompt",
+          "when": "view == pomlPromptGallery",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "poml.gallery.deletePrompt",
+          "when": "view == pomlPromptGallery",
+          "group": "inline"
+        },
+        {
+          "command": "poml.gallery.editPrompt",
+          "when": "view == pomlPromptGallery",
+          "group": "inline"
         }
       ],
       "editor/title/run": [

--- a/package.json
+++ b/package.json
@@ -24,14 +24,14 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id": "pomlGallery",
+          "id": "poml",
           "title": "POML",
           "icon": "./media/icon/poml-icon-16.svg"
         }
       ]
     },
     "views": {
-      "pomlGallery": [
+      "poml": [
         {
           "id": "pomlPromptGallery",
           "name": "Prompt Gallery"
@@ -158,17 +158,20 @@
       {
         "command": "poml.gallery.addPrompt",
         "title": "Add Prompt",
-        "category": "POML"
+        "category": "POML",
+        "icon": "$(plus)"
       },
       {
         "command": "poml.gallery.deletePrompt",
         "title": "Delete Prompt",
-        "category": "POML"
+        "category": "POML",
+        "icon": "$(trashcan)"
       },
       {
         "command": "poml.gallery.editPrompt",
         "title": "Edit Prompt",
-        "category": "POML"
+        "category": "POML",
+        "icon": "$(pencil)"
       }
     ],
     "chatParticipants": [

--- a/packages/poml-vscode/chat/gallery.ts
+++ b/packages/poml-vscode/chat/gallery.ts
@@ -48,6 +48,10 @@ export class PromptGalleryProvider implements vscode.TreeDataProvider<PromptEntr
     this.update(list);
   }
 
+  hasPrompt(name: string): boolean {
+    return this.entries.some(e => e.name === name);
+  }
+
   get prompts(): PromptEntry[] {
     return this.entries;
   }

--- a/packages/poml-vscode/chat/participant.ts
+++ b/packages/poml-vscode/chat/participant.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { getClient } from 'poml-vscode/extension';
 import { PreviewMethodName, PreviewParams, PreviewResponse } from 'poml-vscode/panel/types';
 import { Message } from 'poml';
-import { PromptGalleryProvider } from '../gallery/promptGallery';
+import { PromptGalleryProvider } from '../chat/gallery';
 
 export function registerPomlChatParticipant(context: vscode.ExtensionContext, gallery: PromptGalleryProvider) {
   const handler: vscode.ChatRequestHandler = async (

--- a/packages/poml-vscode/command/index.ts
+++ b/packages/poml-vscode/command/index.ts
@@ -12,3 +12,8 @@ export {
   RemoveContextFileCommand,
   RemoveStylesheetFileCommand,
 } from './addResources';
+export {
+  AddPromptCommand,
+  DeletePromptCommand,
+  EditPromptCommand,
+} from './promptGallery';

--- a/packages/poml-vscode/command/promptGallery.ts
+++ b/packages/poml-vscode/command/promptGallery.ts
@@ -1,0 +1,62 @@
+import * as vscode from 'vscode';
+import { Command } from '../util/commandManager';
+import { PromptGalleryProvider, PromptEntry } from '../gallery/promptGallery';
+import * as path from 'path';
+
+export class AddPromptCommand implements Command {
+  public readonly id = 'poml.gallery.addPrompt';
+  public constructor(private readonly provider: PromptGalleryProvider) {}
+
+  public async execute() {
+    const uri = await vscode.window.showOpenDialog({
+      openLabel: 'Select POML',
+      filters: { POML: ['poml'], 'All Files': ['*'] }
+    });
+    if (!uri || !uri[0]) {
+      return;
+    }
+    const name = await vscode.window.showInputBox({
+      prompt: 'Name for the prompt',
+      value: path.basename(uri[0].fsPath, '.poml')
+    });
+    if (!name) {
+      return;
+    }
+    this.provider.addPrompt({ name, file: uri[0].fsPath });
+  }
+}
+
+export class DeletePromptCommand implements Command {
+  public readonly id = 'poml.gallery.deletePrompt';
+  public constructor(private readonly provider: PromptGalleryProvider) {}
+
+  public execute(item: PromptEntry) {
+    if (item) {
+      this.provider.removePrompt(item);
+    }
+  }
+}
+
+export class EditPromptCommand implements Command {
+  public readonly id = 'poml.gallery.editPrompt';
+  public constructor(private readonly provider: PromptGalleryProvider) {}
+
+  public async execute(item: PromptEntry) {
+    if (!item) {
+      return;
+    }
+    const name = await vscode.window.showInputBox({ prompt: 'Prompt name', value: item.name });
+    if (!name) {
+      return;
+    }
+    const uri = await vscode.window.showOpenDialog({
+      openLabel: 'Select POML',
+      defaultUri: vscode.Uri.file(item.file),
+      filters: { POML: ['poml'], 'All Files': ['*'] }
+    });
+    if (!uri || !uri[0]) {
+      return;
+    }
+    this.provider.updatePrompt(item, { name, file: uri[0].fsPath });
+  }
+}

--- a/packages/poml-vscode/extension.ts
+++ b/packages/poml-vscode/extension.ts
@@ -15,6 +15,7 @@ import {
 import { initializeReporter, getTelemetryReporter, TelemetryClient } from './util/telemetryClient';
 import { TelemetryEvent } from './util/telemetryServer';
 import { registerPomlChatParticipant } from './chat/participant';
+import { registerPromptGallery, PromptGalleryProvider } from './gallery/promptGallery';
 
 let extensionPath = "";
 
@@ -30,6 +31,7 @@ export function activate(context: vscode.ExtensionContext) {
   const logger = new Logger();
 
   const webviewManager = new POMLWebviewPanelManager(context, logger);
+  const galleryProvider = registerPromptGallery(context);
 
   const commandManager = new CommandManager();
   context.subscriptions.push(commandManager);
@@ -46,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
   commandManager.register(new command.RemoveContextFileCommand(webviewManager));
   commandManager.register(new command.RemoveStylesheetFileCommand(webviewManager));
 
-  registerPomlChatParticipant(context);
+  registerPomlChatParticipant(context, galleryProvider);
 
   const connectionString = getConnectionString();
   if (connectionString) {

--- a/packages/poml-vscode/extension.ts
+++ b/packages/poml-vscode/extension.ts
@@ -47,6 +47,9 @@ export function activate(context: vscode.ExtensionContext) {
   commandManager.register(new command.AddStylesheetFileCommand(webviewManager));
   commandManager.register(new command.RemoveContextFileCommand(webviewManager));
   commandManager.register(new command.RemoveStylesheetFileCommand(webviewManager));
+  commandManager.register(new command.AddPromptCommand(galleryProvider));
+  commandManager.register(new command.DeletePromptCommand(galleryProvider));
+  commandManager.register(new command.EditPromptCommand(galleryProvider));
 
   registerPomlChatParticipant(context, galleryProvider);
 

--- a/packages/poml-vscode/extension.ts
+++ b/packages/poml-vscode/extension.ts
@@ -15,7 +15,7 @@ import {
 import { initializeReporter, getTelemetryReporter, TelemetryClient } from './util/telemetryClient';
 import { TelemetryEvent } from './util/telemetryServer';
 import { registerPomlChatParticipant } from './chat/participant';
-import { registerPromptGallery, PromptGalleryProvider } from './gallery/promptGallery';
+import { registerPromptGallery, PromptGalleryProvider } from './chat/gallery';
 
 let extensionPath = "";
 

--- a/packages/poml-vscode/gallery/promptGallery.ts
+++ b/packages/poml-vscode/gallery/promptGallery.ts
@@ -1,0 +1,112 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+export interface PromptEntry {
+  name: string;
+  file: string;
+}
+
+const STORAGE_KEY = 'poml.promptGallery';
+
+export class PromptGalleryProvider implements vscode.TreeDataProvider<PromptEntry> {
+  private _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+  constructor(private context: vscode.ExtensionContext) {}
+
+  private get entries(): PromptEntry[] {
+    return this.context.globalState.get<PromptEntry[]>(STORAGE_KEY, []);
+  }
+
+  private update(entries: PromptEntry[]) {
+    void this.context.globalState.update(STORAGE_KEY, entries);
+    this._onDidChangeTreeData.fire();
+  }
+
+  getChildren(): PromptEntry[] {
+    return this.entries;
+  }
+
+  getTreeItem(element: PromptEntry): vscode.TreeItem {
+    const item = new vscode.TreeItem(element.name, vscode.TreeItemCollapsibleState.None);
+    item.resourceUri = vscode.Uri.file(element.file);
+    item.command = { command: 'vscode.open', title: 'Open Prompt', arguments: [vscode.Uri.file(element.file)] };
+    item.contextValue = 'pomlPrompt';
+    return item;
+  }
+
+  addPrompt(entry: PromptEntry) {
+    const list = [...this.entries, entry];
+    this.update(list);
+  }
+
+  removePrompt(entry: PromptEntry) {
+    this.update(this.entries.filter(e => e !== entry));
+  }
+
+  updatePrompt(entry: PromptEntry, newEntry: PromptEntry) {
+    const list = this.entries.map(e => (e === entry ? newEntry : e));
+    this.update(list);
+  }
+
+  get prompts(): PromptEntry[] {
+    return this.entries;
+  }
+}
+
+export function registerPromptGallery(context: vscode.ExtensionContext): PromptGalleryProvider {
+  const provider = new PromptGalleryProvider(context);
+  const view = vscode.window.createTreeView('pomlPromptGallery', { treeDataProvider: provider });
+  context.subscriptions.push(view);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('poml.gallery.addPrompt', async () => {
+      const uri = await vscode.window.showOpenDialog({
+        openLabel: 'Select POML',
+        filters: { POML: ['poml'], 'All Files': ['*'] }
+      });
+      if (!uri || !uri[0]) {
+        return;
+      }
+      const name = await vscode.window.showInputBox({
+        prompt: 'Name for the prompt',
+        value: path.basename(uri[0].fsPath, '.poml')
+      });
+      if (!name) {
+        return;
+      }
+      provider.addPrompt({ name, file: uri[0].fsPath });
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('poml.gallery.deletePrompt', (item: PromptEntry) => {
+      if (item) {
+        provider.removePrompt(item);
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('poml.gallery.editPrompt', async (item: PromptEntry) => {
+      if (!item) {
+        return;
+      }
+      const name = await vscode.window.showInputBox({ prompt: 'Prompt name', value: item.name });
+      if (!name) {
+        return;
+      }
+      const uri = await vscode.window.showOpenDialog({
+        openLabel: 'Select POML',
+        defaultUri: vscode.Uri.file(item.file),
+        filters: { POML: ['poml'], 'All Files': ['*'] }
+      });
+      if (!uri || !uri[0]) {
+        return;
+      }
+      provider.updatePrompt(item, { name, file: uri[0].fsPath });
+    })
+  );
+
+  return provider;
+}

--- a/packages/poml-vscode/gallery/promptGallery.ts
+++ b/packages/poml-vscode/gallery/promptGallery.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 export interface PromptEntry {
   name: string;
@@ -58,55 +57,5 @@ export function registerPromptGallery(context: vscode.ExtensionContext): PromptG
   const provider = new PromptGalleryProvider(context);
   const view = vscode.window.createTreeView('pomlPromptGallery', { treeDataProvider: provider });
   context.subscriptions.push(view);
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('poml.gallery.addPrompt', async () => {
-      const uri = await vscode.window.showOpenDialog({
-        openLabel: 'Select POML',
-        filters: { POML: ['poml'], 'All Files': ['*'] }
-      });
-      if (!uri || !uri[0]) {
-        return;
-      }
-      const name = await vscode.window.showInputBox({
-        prompt: 'Name for the prompt',
-        value: path.basename(uri[0].fsPath, '.poml')
-      });
-      if (!name) {
-        return;
-      }
-      provider.addPrompt({ name, file: uri[0].fsPath });
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('poml.gallery.deletePrompt', (item: PromptEntry) => {
-      if (item) {
-        provider.removePrompt(item);
-      }
-    })
-  );
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand('poml.gallery.editPrompt', async (item: PromptEntry) => {
-      if (!item) {
-        return;
-      }
-      const name = await vscode.window.showInputBox({ prompt: 'Prompt name', value: item.name });
-      if (!name) {
-        return;
-      }
-      const uri = await vscode.window.showOpenDialog({
-        openLabel: 'Select POML',
-        defaultUri: vscode.Uri.file(item.file),
-        filters: { POML: ['poml'], 'All Files': ['*'] }
-      });
-      if (!uri || !uri[0]) {
-        return;
-      }
-      provider.updatePrompt(item, { name, file: uri[0].fsPath });
-    })
-  );
-
   return provider;
 }


### PR DESCRIPTION
## Summary
- create PromptGalleryProvider to manage prompt files
- register gallery and add slash commands to poml chat participant
- show gallery in VS Code activity bar and provide context menus

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pip install -e .[dev]`
- `python -m pytest python/tests`
- `xvfb-run -a npm run compile`
- `npm run build-extension`
- `xvfb-run -a npm run test-vscode`


------
https://chatgpt.com/codex/tasks/task_e_686e4109f910832e81ed48e4f2b20f33