### PR TITLE
Add selective alias disable and version check

### DIFF
--- a/packages/poml/file.tsx
+++ b/packages/poml/file.tsx
@@ -601,7 +601,7 @@ export class PomlFile {
           return;
         }
         const op = token[0];
-        const name = token.slice(1).toLowerCase();
+        const name = token.slice(1).toLowerCase().trim();
         if (!name) {
           return;
         }
@@ -1151,9 +1151,16 @@ const camelToHyphenCase = (text: string): string => {
   return text.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 };
 
+/**
+ * Compares two semantic version strings (e.g., "1.2.3").
+ * 
+ * @param a - The first version string in the format "x.y.z".
+ * @param b - The second version string in the format "x.y.z".
+ * @returns -1 if `a` is less than `b`, 1 if `a` is greater than `b`, and 0 if they are equal.
+ */
 const compareVersions = (a: string, b: string): number => {
-  const pa = a.split('.').map(n => parseInt(n));
-  const pb = b.split('.').map(n => parseInt(n));
+  const pa = a.split('.').map(n => parseInt(n, 10));
+  const pb = b.split('.').map(n => parseInt(n, 10));
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;

--- a/packages/poml/file.tsx
+++ b/packages/poml/file.tsx
@@ -19,6 +19,7 @@ import { AnyValue, deepMerge, parseText, readSource } from './util';
 import { StyleSheetProvider, ErrorCollection } from './base';
 import { getSuggestions } from './util/xmlContentAssist';
 import path from 'path';
+import { POML_VERSION } from './version';
 
 export interface PomlReaderOptions {
   trim?: boolean;
@@ -56,6 +57,7 @@ export class PomlFile {
   private cst: CstNode;
   private tokenVector: IToken[];
   private documentRange: Range;
+  private disabledComponents: Set<string> = new Set();
 
   constructor(text: string, options?: PomlReaderOptions, sourcePath?: string) {
     this.config = {
@@ -572,6 +574,43 @@ export class PomlFile {
     return <>{resultNodes}</>;
   };
 
+  private handleMeta = (element: XMLElement): boolean => {
+    if (element.name?.toLowerCase() !== 'meta') {
+      return false;
+    }
+    const minVersion = xmlAttribute(element, 'minVersion')?.value;
+    if (minVersion && compareVersions(POML_VERSION, minVersion) < 0) {
+      this.reportError(
+        `POML version ${minVersion} or higher is required`,
+        this.xmlAttributeValueRange(xmlAttribute(element, 'minVersion')!)
+      );
+    }
+    const maxVersion = xmlAttribute(element, 'maxVersion')?.value;
+    if (maxVersion && compareVersions(POML_VERSION, maxVersion) > 0) {
+      this.reportError(
+        `POML version ${maxVersion} or lower is required`,
+        this.xmlAttributeValueRange(xmlAttribute(element, 'maxVersion')!)
+      );
+    }
+
+    const comps = xmlAttribute(element, 'components')?.value;
+    if (comps) {
+      comps.split(/[,\s]+/).forEach(token => {
+        token = token.trim();
+        if (!token) return;
+        const op = token[0];
+        const name = token.slice(1).toLowerCase();
+        if (!name) return;
+        if (op === '+') {
+          this.disabledComponents.delete(name);
+        } else if (op === '-') {
+          this.disabledComponents.add(name);
+        }
+      });
+    }
+    return true;
+  };
+
   private unescapeText = (text: string): string => {
     return text
       .replace(/#lt;/g, '<')
@@ -667,6 +706,10 @@ export class PomlFile {
       return <></>;
     }
 
+    if (this.handleMeta(element)) {
+      return <></>;
+    }
+
     const tagName = element.name;
     if (!tagName) {
       // Probably already had an invalid syntax error.
@@ -703,7 +746,7 @@ export class PomlFile {
         }
       } else {
         // Logic for all other components
-        const component = findComponentByAlias(tagName);
+        const component = findComponentByAlias(tagName, this.disabledComponents);
         if (typeof component === 'string') {
           // Add a read error
           this.reportError(component, this.xmlOpenNameRange(element));
@@ -922,7 +965,10 @@ export class PomlFile {
       const excludedComponents: string[] = [];
       if (element.name) {
         candidates.push(element.name);
-        const component = findComponentByAliasOrUndefined(element.name);
+        const component = findComponentByAliasOrUndefined(
+          element.name,
+          this.disabledComponents
+        );
         if (component !== undefined) {
           excludedComponents.push(component.name);
         }
@@ -955,7 +1001,10 @@ export class PomlFile {
       if (!element.name) {
         return [];
       }
-      const component = findComponentByAliasOrUndefined(element.name);
+      const component = findComponentByAliasOrUndefined(
+        element.name,
+        this.disabledComponents
+      );
       const parameters = component?.parameters();
       if (!component || !parameters) {
         return [];
@@ -991,7 +1040,10 @@ export class PomlFile {
       if (!element.name) {
         return [];
       }
-      const component = findComponentByAliasOrUndefined(element.name);
+      const component = findComponentByAliasOrUndefined(
+        element.name,
+        this.disabledComponents
+      );
       const parameters = component?.parameters();
       if (!component || !parameters) {
         return [];
@@ -1088,6 +1140,18 @@ const hyphenToCamelCase = (text: string): string => {
 
 const camelToHyphenCase = (text: string): string => {
   return text.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+};
+
+const compareVersions = (a: string, b: string): number => {
+  const pa = a.split('.').map(n => parseInt(n));
+  const pb = b.split('.').map(n => parseInt(n));
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na > nb) return 1;
+    if (na < nb) return -1;
+  }
+  return 0;
 };
 
 const xmlAttribute = (element: XMLElement, key: string): XMLAttribute | undefined => {

--- a/packages/poml/file.tsx
+++ b/packages/poml/file.tsx
@@ -597,14 +597,23 @@ export class PomlFile {
     if (comps) {
       comps.split(/[,\s]+/).forEach(token => {
         token = token.trim();
-        if (!token) return;
+        if (!token) {
+          return;
+        }
         const op = token[0];
         const name = token.slice(1).toLowerCase();
-        if (!name) return;
+        if (!name) {
+          return;
+        }
         if (op === '+') {
           this.disabledComponents.delete(name);
         } else if (op === '-') {
           this.disabledComponents.add(name);
+        } else {
+          this.reportError(
+            `Invalid component operation: ${op}. Use + to enable or - to disable.`,
+            this.xmlAttributeValueRange(xmlAttribute(element, 'components')!)
+          );
         }
       });
     }
@@ -636,9 +645,9 @@ export class PomlFile {
         context,
         position
           ? {
-              start: position.start + curlyMatch.index,
-              end: position.start + curlyMatch.index + curlyMatch[0].length - 1
-            }
+            start: position.start + curlyMatch.index,
+            end: position.start + curlyMatch.index + curlyMatch[0].length - 1
+          }
           : undefined
       );
       if (this.config.trim && curlyMatch[0] === text.trim()) {
@@ -1148,8 +1157,12 @@ const compareVersions = (a: string, b: string): number => {
   for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;
-    if (na > nb) return 1;
-    if (na < nb) return -1;
+    if (na > nb) {
+      return 1;
+    }
+    if (na < nb) {
+      return -1;
+    }
   }
   return 0;
 };

--- a/packages/poml/tests/meta.test.tsx
+++ b/packages/poml/tests/meta.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { describe, expect, test } from '@jest/globals';
+import { poml, read, write } from 'poml';
+import { ErrorCollection, ReadError, component, unregisterComponent } from 'poml/base';
+
+
+describe('meta tag', () => {
+  test('version check pass', async () => {
+    const result = await poml('<meta minVersion="0.0.1" maxVersion="0.0.6"/><p>hi</p>');
+    expect(result).toBe('hi');
+  });
+
+  test('version check fail', async () => {
+    const fn = async () => {
+      ErrorCollection.clear();
+      await read('<meta minVersion="9.9.9"/><p>hi</p>');
+      if (!ErrorCollection.empty()) {
+        throw ErrorCollection.first();
+      }
+    };
+    await expect(fn).rejects.toThrow(ReadError);
+  });
+
+  test('disable component', async () => {
+    const fn = async () => {
+      ErrorCollection.clear();
+      await read('<poml><meta components="-table"/><table records="a,b\n1,2" parser="csv"/></poml>');
+      if (!ErrorCollection.empty()) {
+        throw ErrorCollection.first();
+      }
+    };
+    await expect(fn).rejects.toThrow(ReadError);
+  });
+
+  test('re-enable component', async () => {
+    const result = write(
+      await read('<poml><meta components="-table"/><meta components="+table"/><table records="a,b\n1,2" parser="csv"/></poml>')
+    );
+    expect(result).toMatch(/\|/);
+  });
+
+  test('disable alias only', async () => {
+    const Hello = component('Hello', { aliases: ['hi'] })(() => {
+      return <p>hi</p>;
+    });
+    const fail = async () => {
+      ErrorCollection.clear();
+      await read('<poml><meta components="-hi"/><hi/></poml>');
+      if (!ErrorCollection.empty()) {
+        throw ErrorCollection.first();
+      }
+    };
+    await expect(fail).rejects.toThrow(ReadError);
+
+    const ok = await read('<poml><meta components="-hi"/><Hello/></poml>');
+    expect(ok).toContain('hi');
+    unregisterComponent('Hello');
+  });
+});

--- a/packages/poml/version.ts
+++ b/packages/poml/version.ts
@@ -1,0 +1,1 @@
+export const POML_VERSION = "0.0.6";


### PR DESCRIPTION
## Summary
- store disabled component aliases in `PomlFile`
- allow `getComponent` to take a disabled set
- skip disabled aliases when searching and suggesting
- expand meta tag tests to cover alias-only disabling
- Support minVersion and maxVersion check

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint` *(with warnings)*
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_687739351228832eb5d8933aca68352d