### PR TITLE
Fix publish workflow NPM packaging

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,7 +125,7 @@ jobs:
     - name: Pack NPM package
       if: matrix.os == 'ubuntu-latest'
       run: |
-        cd packages/poml
+        cd packages/poml-build
         npm pack
 
     - name: Upload NPM package
@@ -133,5 +133,5 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: poml-npm-universal
-        path: packages/poml/poml-*.tgz
+        path: packages/poml-build/poml-*.tgz
         compression-level: 0


### PR DESCRIPTION
## Summary
- fix path to pack NPM package in `publish.yml`

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_688212d27de4832e967191a47f04047a