### PR TITLE
Enable tracing artifacts and pretty result dumps

### DIFF
--- a/packages/poml/index.ts
+++ b/packages/poml/index.ts
@@ -167,27 +167,15 @@ export async function commandLine(args: CliArgs) {
 
   const speakerMode = args.speakerMode === true || args.speakerMode === undefined;
   const prettyPrint = args.prettyPrint === true;
-  let output: string = '';
-  let result: any;
-  if (prettyPrint) {
-    if (speakerMode) {
-      result = write(ir, { speaker: true });
-      const outputs = (result as Message[]).map((message) => {
-        return `===== ${message.speaker} =====\n\n${renderContent(message.content)}`;
-      });
-      output = outputs.join('\n\n');
-    } else {
-      result = write(ir);
-      output = renderContent(result);
-    }
-  } else {
-    result = write(ir, { speaker: speakerMode });
-    output = JSON.stringify(result);
-  }
+  let result = write(ir, { speaker: speakerMode });
+  const prettyOutput = speakerMode
+    ? (result as Message[]).map((message) => `===== ${message.speaker} =====\n\n${renderContent(message.content)}`).join('\n\n')
+    : renderContent(result as RichContent);
+  const output = prettyPrint ? prettyOutput : JSON.stringify(result);
 
   if (isTracing()) {
     try {
-      dumpTrace(input, context, stylesheet, result, sourcePath);
+      dumpTrace(input, context, stylesheet, result, sourcePath, prettyOutput);
     } catch (err: any) {
       ErrorCollection.add(new SystemError('Failed to dump trace', { cause: err }));
     }

--- a/packages/poml/tests/trace.test.tsx
+++ b/packages/poml/tests/trace.test.tsx
@@ -39,6 +39,12 @@ describe('trace dumps', () => {
     expect(images).toBe(true);
   });
 
+  test('pretty printed result text is dumped', async () => {
+    await commandLine({ input: '<p>Hello</p>', speakerMode: false });
+    const text = fs.readFileSync(path.join(traceDir, '0001.result.txt'), 'utf8').trim();
+    expect(text).toBe('Hello');
+  });
+
   test('env file records source path and enables include', async () => {
     const origDir = fs.mkdtempSync(path.join(os.tmpdir(), 'orig-'));
     const mainPath = path.join(origDir, 'main.poml');

--- a/packages/poml/util/trace.ts
+++ b/packages/poml/util/trace.ts
@@ -81,7 +81,7 @@ function nextIndex(sourcePath?: string): [number, string, number] {
   }
 }
 
-export function dumpTrace(markup: string, context?: any, stylesheet?: any, result?: any, sourcePath?: string) {
+export function dumpTrace(markup: string, context?: any, stylesheet?: any, result?: any, sourcePath?: string, prettyResult?: string) {
   if (!isTracing()) {
     return;
   }
@@ -109,6 +109,9 @@ export function dumpTrace(markup: string, context?: any, stylesheet?: any, resul
   }
   if (result !== undefined) {
     writeFileSync(`${prefix}.result.json`, JSON.stringify(replaceBuffers(result), null, 2));
+    if (prettyResult !== undefined) {
+      writeFileSync(`${prefix}.result.txt`, prettyResult);
+    }
   }
 }
 

--- a/python/poml/__init__.py
+++ b/python/poml/__init__.py
@@ -1,5 +1,5 @@
 from ._version import __version__
 
-from .api import poml, set_trace, clear_trace, get_trace
+from .api import poml, set_trace, clear_trace, get_trace, trace_artifact
 from .cli import entrypoint, run
 from .prompt import Prompt

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -5,7 +5,7 @@ import re
 from pathlib import Path
 import multiprocessing
 
-from poml import poml, Prompt, set_trace, clear_trace, get_trace
+from poml import poml, Prompt, set_trace, clear_trace, get_trace, trace_artifact
 
 
 def test_basic():
@@ -101,6 +101,29 @@ def test_trace_directory(tmp_path: Path):
     assert result == [{"speaker": "human", "content": "Dir"}]
     files = list(run_dir.glob("*.poml"))
     assert len(files) == 2
+
+
+def test_trace_artifact(tmp_path: Path):
+    clear_trace()
+    run_dir = set_trace(True, tmp_path)
+    poml("<p>A</p>")
+    trace_artifact("reply.txt", "hello")
+    set_trace(False)
+    artifacts = list(run_dir.glob("*.reply.txt"))
+    assert len(artifacts) == 1
+    assert artifacts[0].read_text().strip() == "hello"
+
+
+def test_trace_prefix_regex(tmp_path: Path):
+    clear_trace()
+    run_dir = set_trace(True, tmp_path)
+    src = tmp_path / "my.file.poml"
+    src.write_text("<p>B</p>")
+    poml(src)
+    trace_artifact("custom.txt", "bye")
+    set_trace(False)
+    artifact = run_dir / "0001.my.file.custom.txt"
+    assert artifact.exists()
 
 
 def test_trace_directory_name_format(tmp_path: Path):


### PR DESCRIPTION
## Summary
- dump pretty results to `.result.txt` for JS traces
- add `trace_artifact` helper to Python API
- support new artifact files in tests
- infer latest trace prefix instead of tracking globals
- use regex to locate latest trace prefix in python
- ensure regex logic handles filenames with dots

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_68875447fe1c832e922bc6e3fcb1ee58