### PR TITLE
Support per-resource options for prompts

### DIFF
--- a/packages/poml-vscode/command/testCommand.ts
+++ b/packages/poml-vscode/command/testCommand.ts
@@ -175,13 +175,13 @@ export class TestCommand implements Command {
   }
 
   private async renderPrompt(uri: vscode.Uri) {
+    const options = this.previewManager.previewConfigurations.getResourceOptions(uri);
     const requestParams: PreviewParams = {
       uri: uri.toString(),
       speakerMode: this.isChatting,
       displayFormat: 'rendered',
-      // FIXME: Use contexts and stylesheets configured
-      contexts: [],
-      stylesheets: [],
+      contexts: options.contexts,
+      stylesheets: options.stylesheets,
     };
 
     const response: PreviewResponse = await getClient().sendRequest<PreviewResponse>(

--- a/packages/poml-vscode/panel/panel.ts
+++ b/packages/poml-vscode/panel/panel.ts
@@ -251,10 +251,12 @@ export class POMLWebviewPanel {
 
     // If we have changed resources, cancel any pending updates
     const isResourceChange = resource.fsPath !== this._pomlUri.fsPath;
-    if (isResourceChange || this.firstUpdate) {
+    if (isResourceChange) {
       clearTimeout(this.throttleTimer);
       this.throttleTimer = undefined;
+    }
 
+    if (isResourceChange || this.firstUpdate) {
       const saved = this._previewConfigurations.getResourceOptions(resource);
       this._userOptions.contexts = [...saved.contexts];
       this._userOptions.stylesheets = [...saved.stylesheets];


### PR DESCRIPTION
## Summary
- manage contexts and stylesheets per resource in `SettingsManager`
- use the central resource options store from `POMLWebviewPanel`
- honor configured resource options in test command

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`
- `xvfb-run -a npm run compile`
- `npm run build-extension`
- `xvfb-run -a npm run test-vscode`


------
https://chatgpt.com/codex/tasks/task_e_68886c324158832eb716cae990bb7119