### PR TITLE
test: ensure if evaluated in loop

### DIFF
--- a/packages/poml/tests/file.test.tsx
+++ b/packages/poml/tests/file.test.tsx
@@ -182,6 +182,16 @@ describe('templateEngine', () => {
     expect(await poml(text)).toBe('1\n\n2\n\n3');
   })
 
+  test('forLoopIf', async () => {
+    const text = '<p><p for="i in [0,1,2]" if="i % 2 == 0">{{i}}</p></p>';
+    expect(await poml(text)).toBe('0\n\n2');
+  });
+
+  test('forLoopIfLoopIndex', async () => {
+    const text = '<p><p for="i in [1,2]" if="loop.index == 1">{{i}}</p></p>';
+    expect(await poml(text)).toBe('2');
+  });
+
   test('ifCondition', async () => {
     const text =
       '<p><p if="true">hello</p><p if="i == 0">world</p><p if="{{ i == 1 }}">foo</p></p>';


### PR DESCRIPTION
## Summary
- test for evaluating `if` attribute on each iteration of a `for` loop

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_688a3ef9b05c832eb575d6eee8686b92