### PR TITLE
refactor: centralize fs usage in poml

### DIFF
--- a/packages/poml/components/document.tsx
+++ b/packages/poml/components/document.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as fs from 'fs';
+import fs from '../util/fs';
 import * as mammoth from 'mammoth';
 import * as cheerio from 'cheerio';
 

--- a/packages/poml/components/table.tsx
+++ b/packages/poml/components/table.tsx
@@ -4,7 +4,7 @@ import { PropsSyntaxBase, computeSyntaxContext } from 'poml/essentials';
 import { component, expandRelative } from 'poml/base';
 import { parseText, guessStringType, AnyValue } from 'poml/util';
 import { csvParse, tsvParse, DSVRowArray } from 'd3-dsv';
-import { readFileSync } from 'fs';
+import { readFileSync } from '../util/fs';
 import * as XLSX from 'xlsx';
 import { parsePythonStyleSlice } from './utils';
 

--- a/packages/poml/components/tree.tsx
+++ b/packages/poml/components/tree.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as fs from 'fs';
+import fs from '../util/fs';
 import * as path from 'path';
 import {
   PropsSyntaxBase,

--- a/packages/poml/components/webpage.tsx
+++ b/packages/poml/components/webpage.tsx
@@ -1,6 +1,6 @@
 import { PropsSyntaxBase } from 'poml/essentials';
 import * as React from 'react';
-import * as fs from 'fs';
+import fs from '../util/fs';
 import { component, expandRelative, useWithCatch } from 'poml/base';
 import { Text } from 'poml/essentials';
 import * as cheerio from 'cheerio';

--- a/packages/poml/essentials.tsx
+++ b/packages/poml/essentials.tsx
@@ -13,7 +13,7 @@ import {
   Free,
   MultiMedia
 } from './presentation';
-import fs from 'fs';
+import fs from './util/fs';
 import { preprocessImage } from './util/image';
 import { preprocessAudio } from './util/audio';
 

--- a/packages/poml/file.tsx
+++ b/packages/poml/file.tsx
@@ -18,7 +18,7 @@ import {
 import { AnyValue, deepMerge, parseText, readSource } from './util';
 import { StyleSheetProvider, ErrorCollection } from './base';
 import { getSuggestions } from './util/xmlContentAssist';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync, readFileSync } from './util/fs';
 import path from 'path';
 import { POML_VERSION } from './version';
 

--- a/packages/poml/index.ts
+++ b/packages/poml/index.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from './util/fs';
 import { renderToString } from "react-dom/server";
 import path from 'path';
 import { EnvironmentDispatcher } from "./writer";

--- a/packages/poml/tests/components.test.tsx
+++ b/packages/poml/tests/components.test.tsx
@@ -6,9 +6,8 @@ import { poml, read, write } from 'poml';
 import { readDocx, readDocxFromPath, readPdfFromPath, readTxtFromPath, Document } from 'poml/components/document';
 import { Tree, TreeItemData, Folder } from 'poml/components/tree';
 import { Webpage } from 'poml/components/webpage';
-import { readFileSync } from 'fs';
+import { readFileSync, mkdirSync, existsSync } from '../util/fs';
 import { ErrorCollection, BufferCollection } from 'poml/base';
-import { mkdirSync, existsSync } from 'fs';
 import * as path from 'path';
 
 describe('document', () => {

--- a/packages/poml/tests/index.test.tsx
+++ b/packages/poml/tests/index.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import * as fs from 'fs';
+import fs from '../util/fs';
 import * as path from 'path';
 
 import { beforeAll, afterAll, describe, expect, test, jest } from '@jest/globals';

--- a/packages/poml/tests/table.test.tsx
+++ b/packages/poml/tests/table.test.tsx
@@ -18,7 +18,7 @@ import { Code, Text, Inline } from 'poml/essentials';
 import { HtmlWriter, MarkdownWriter } from 'poml/writer';
 import { read, write } from 'poml';
 import { ErrorCollection } from 'poml/base';
-import { readFileSync } from 'fs';
+import { readFileSync } from '../util/fs';
 
 describe('other formats', () => {
   test('csv', () => {

--- a/packages/poml/tests/trace.test.tsx
+++ b/packages/poml/tests/trace.test.tsx
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import fs from '../util/fs';
 import * as os from 'os';
 import * as path from 'path';
 import { describe, beforeEach, afterEach, test, expect } from '@jest/globals';

--- a/packages/poml/tests/util.test.tsx
+++ b/packages/poml/tests/util.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { describe, expect, test } from '@jest/globals';
-import { readFileSync } from 'fs';
+import { readFileSync } from '../util/fs';
 import { component } from 'poml/base';
 import { Writable } from 'stream';
 import { parseText, readSource } from 'poml/util';

--- a/packages/poml/tests/writer.test.tsx
+++ b/packages/poml/tests/writer.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { describe, expect, test } from '@jest/globals';
 import { MarkdownWriter, JsonWriter, MultiMediaWriter, YamlWriter, XmlWriter } from 'poml/writer';
 import * as cheerio from 'cheerio';
-import { readFileSync } from 'fs';
+import { readFileSync } from '../util/fs';
 import { ErrorCollection, richContentFromSourceMap } from 'poml/base';
 
 describe('markdown', () => {

--- a/packages/poml/util/audio.ts
+++ b/packages/poml/util/audio.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs from './fs';
 import path from 'path';
 
 interface PreprocessAudioArgs {

--- a/packages/poml/util/fs.ts
+++ b/packages/poml/util/fs.ts
@@ -1,0 +1,12 @@
+import * as fs from 'fs';
+
+export const readFileSync = fs.readFileSync;
+export const writeFileSync = fs.writeFileSync;
+export const existsSync = fs.existsSync;
+export const mkdirSync = fs.mkdirSync;
+export const openSync = fs.openSync;
+export const closeSync = fs.closeSync;
+export const writeSync = fs.writeSync;
+export const symlinkSync = fs.symlinkSync;
+
+export default fs;

--- a/packages/poml/util/index.ts
+++ b/packages/poml/util/index.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync } from './fs';
 import path from "path";
 
 export const deepMerge = (target: any, source: any): any => {

--- a/packages/poml/util/trace.ts
+++ b/packages/poml/util/trace.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync, openSync, closeSync, writeSync, symlinkSync } from 'fs';
+import { mkdirSync, writeFileSync, openSync, closeSync, writeSync, symlinkSync } from './fs';
 import path from 'path';
 
 interface Base64Wrapper { __base64__: string }


### PR DESCRIPTION
## Summary
- provide an `fs` wrapper so filesystem access can be mocked when bundling for the browser
- route all `packages/poml` imports through the new wrapper

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_68905af06674832eb9d215e89e0fcfb1