### PR TITLE
feat: add expression evaluation codelens

### DIFF
--- a/packages/poml-vscode/tests/lsp.test.ts
+++ b/packages/poml-vscode/tests/lsp.test.ts
@@ -117,5 +117,14 @@ suite('LSP Server', () => {
     assert.strictEqual(response.error, undefined, 'Preview response contains error');
     assert.ok(response.content, 'Expected preview content');
   });
+
+  test('evaluate expression returns result', async function() {
+    this.timeout(20000);
+    const result = await client.sendRequest('workspace/executeCommand', {
+      command: 'poml.evaluateExpression',
+      arguments: [0, '<p>{{1+2}}</p>']
+    });
+    assert.strictEqual(result, 3, 'Evaluation result mismatch');
+  });
 });
 

--- a/packages/poml/tests/file.test.tsx
+++ b/packages/poml/tests/file.test.tsx
@@ -245,6 +245,30 @@ describe('templateEngine', () => {
   });
 });
 
+describe('expressionEvaluation', () => {
+  test('captures evaluation history', () => {
+    ErrorCollection.clear();
+    const text = '<p for="i in [1,2]">{{i}}</p>';
+    const file = new PomlFile(text);
+    file.react();
+    const tokens = file.getExpressionTokens();
+    expect(tokens.length).toBe(2);
+    expect(file.getExpressionEvaluations(1)).toStrictEqual([1, 2]);
+    expect(ErrorCollection.empty()).toBe(true);
+  });
+
+  test('tracks each expression separately', () => {
+    ErrorCollection.clear();
+    const text = '<p>{{1+2}} {{1+2}}</p>';
+    const file = new PomlFile(text);
+    file.react();
+    const tokens = file.getExpressionTokens();
+    expect(tokens.length).toBe(2);
+    expect(file.getExpressionEvaluations(0)).toStrictEqual([3]);
+    expect(file.getExpressionEvaluations(1)).toStrictEqual([3]);
+  });
+});
+
 describe('include', () => {
   test('basic include', async () => {
     const text = '<poml><include src="assets/includeChild.poml"/></poml>';


### PR DESCRIPTION
## Summary
- log all evaluations for expressions and return latest result by index
- track evaluations per token range to disambiguate duplicate expressions
- verify expression evaluation recording with new tests

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`
- `xvfb-run -a npm run compile`
- `xvfb-run -a npm run test-vscode` *(failed: module load errors, 8 tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_688dea8b66d0832eb9d783cb03d63930