### PR TITLE
Retry macOS 13 VS Code test step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,14 @@ jobs:
       - run: python -m pytest -v python/tests
       - run: xvfb-run -a npm run compile && xvfb-run -a npm run test-vscode
         if: runner.os == 'Linux'
+      - uses: nick-invision/retry@v3
+        if: matrix.os == 'macos-13'
+        with:
+          max_attempts: 3
+          timeout_minutes: 10
+          command: npm run compile && npm run test-vscode
       - run: npm run compile && npm run test-vscode
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && matrix.os != 'macos-13'
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- retry VS Code extension tests on macOS 13 to mitigate flaky failures

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_689e04e59f90832eb84c38df98839515