### PR TITLE
docs: add mini-poml-rs community project

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ For detailed information on POML syntax, components, styling, templating, SDKs, 
 * **Join our Discord community:** Connect with the team and other users on our [Discord server](https://discord.gg/FhMCqWzAn6).
 * **Read the Research Paper (coming soon):** For an in-depth understanding of POML's design, implementation, and evaluation, check out our paper: [Paper link TBD](TBD).
 
+## Ecosystem & Community Projects
+
+- [mini-poml-rs](https://github.com/linmx0130/mini-poml-rs) – Experimental Rust-based POML renderer for environments without JavaScript or Python interpreters.
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.opensource.microsoft.com.

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,10 @@ Welcome to the Prompt Orchestration Markup Language (POML) documentation.
 - [TypeScript SDK](./typescript/index.md): Use the POML TypeScript API for building applications.
 - [Python SDK](./python/index.md): Integrate POML into your Python projects.
 
+## Ecosystem & Community Projects
+
+- [mini-poml-rs](https://github.com/linmx0130/mini-poml-rs) – Experimental Rust-based POML renderer for environments without JavaScript or Python interpreters.
+
 ## Community
 
 Join our Discord community: Connect with the team and other users on our [Discord server](https://discord.gg/FhMCqWzAn6).


### PR DESCRIPTION
## Summary
- document the experimental Rust-based POML renderer mini-poml-rs in a new ecosystem section

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a2bca1ed30832e890034b24217a708