### PR TITLE
ci: check component spec generation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,8 @@ jobs:
       - run: npm run build-webview
       - run: npm run build-cli
       - run: npm run lint
+      - run: npm run validate-component-spec
+        if: matrix.os == 'ubuntu-latest'
       - run: npm run package:win
         if: matrix.platform == 'win32-x64'
       - run: npm run package -- --target ${{ matrix.platform }}

--- a/package.json
+++ b/package.json
@@ -348,6 +348,7 @@
     "build-webview": "webpack-cli --config webpack.config.webview.js",
     "build-cli": "webpack-cli --config webpack.config.cli.js",
     "generate-component-spec": "npm run compile && node ./out/poml-vscode/lsp/parseComments.js && npm run compile && node ./out/poml-vscode/lsp/parseComments.js",
+    "validate-component-spec": "npm run compile && node ./out/poml-vscode/lsp/parseComments.js --check && npm run compile && node ./out/poml-vscode/lsp/parseComments.js --check",
     "generate-vscodeignore": "node ./vscodeignore.js",
     "compile": "tspc -p ./",
     "watch": "tspc -watch -p ./",


### PR DESCRIPTION
## Summary
- run component specification generation in CI in check mode to ensure docs stay in sync
- add `--check` mode to component spec generator
- add `validate-component-spec` script to run check mode for both generation passes

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `python -m pytest python/tests`
- `npm run validate-component-spec`


------
https://chatgpt.com/codex/tasks/task_e_68a2b36dd92c832e8e99049f6f099af9