### PR TITLE
Support tool use in Python SDK

### DIFF
--- a/docs/language/standalone.md
+++ b/docs/language/standalone.md
@@ -481,12 +481,23 @@ Runtime parameters configure the language model's behavior during execution. The
 
 ```xml
 <runtime temperature="0.7" 
-         maxOutputTokens="1000" 
+         max-output-tokens="1000" 
          model="gpt-5"
-         topP="0.9" />
+         top_p="0.9" />
 ```
 
-All attributes are passed as runtime parameters. Common parameters include:
+All attributes are passed as runtime parameters with automatic type conversion:
+
+### Key Conversion
+- Keys are converted from kebab-case to camelCase
+- Examples: `max-tokens` → `maxTokens`, `top-p` → `topP`, `frequency-penalty` → `frequencyPenalty`
+
+### Value Conversion
+- **Boolean strings**: `"true"` and `"false"` → `true` and `false`
+- **Number strings**: `"1000"`, `"0.7"` → `1000`, `0.7`
+- **JSON strings**: `'["END", "STOP"]'`, `'{"key": "value"}'` → parsed JSON objects/arrays
+
+### Common Parameters
 
 - **temperature**: Controls randomness (0-2, typically 0.3-0.7 for balanced output)
 - **maxOutputTokens**: Maximum response length in tokens

--- a/docs/language/standalone.md
+++ b/docs/language/standalone.md
@@ -473,6 +473,41 @@ In expression mode, the `z` variable is automatically available for constructing
 - **description**: Tool description (optional but recommended)
 - **lang**: Schema language, either "json" or "expr" (optional, auto-detected based on content)
 
+### Template Expressions in Attributes
+
+Both schemas and tools support template expressions in their attributes:
+
+```xml
+<let name="toolName">calculate</let>
+<let name="toolDesc">Perform mathematical calculations</let>
+<let name="schemaLang">json</let>
+
+<tool-definition name="{{toolName}}" description="{{toolDesc}}" lang="{{schemaLang}}">
+  {
+    "type": "object",
+    "properties": {
+      "operation": { "type": "string" }
+    }
+  }
+</tool-definition>
+```
+
+Similarly for output schemas:
+
+```xml
+<let name="schemaJson">
+{
+  "type": "object",
+  "properties": {
+    "result": { "type": "string" }
+  }
+}
+</let>
+<output-schema lang="json">
+{{ schemaJson }}
+</output-schema>
+```
+
 You can define multiple tools in a single document.
 
 ## Runtime Parameters

--- a/packages/poml/tests/file.test.tsx
+++ b/packages/poml/tests/file.test.tsx
@@ -690,16 +690,136 @@ describe('meta elements', () => {
 
   test('runtime parameters', () => {
     const text = `<poml>
-      <runtime temperature="0.7" max_tokens="1000" model="gpt-4">
+      <runtime temperature="0.7" max-tokens="1000" model="gpt-4">
       </runtime>
     </poml>`;
     const file = new PomlFile(text);
     file.react();
     const runtimeParams = file.getRuntimeParameters();
     expect(runtimeParams).toEqual({
-      temperature: "0.7",
-      max_tokens: "1000",
+      temperature: 0.7,
+      maxTokens: 1000,
       model: "gpt-4"
+    });
+  });
+
+  test('runtime parameters with key conversion', () => {
+    const text = `<poml>
+      <runtime 
+        max-tokens="1500" 
+        top-p="0.9" 
+        frequency-penalty="0.5"
+        presence-penalty="0.3"
+        stop-sequences='["END", "STOP"]'
+      />
+    </poml>`;
+    const file = new PomlFile(text);
+    file.react();
+    const runtimeParams = file.getRuntimeParameters();
+    expect(runtimeParams).toEqual({
+      maxTokens: 1500,
+      topP: 0.9,
+      frequencyPenalty: 0.5,
+      presencePenalty: 0.3,
+      stopSequences: ["END", "STOP"]
+    });
+  });
+
+  test('runtime parameters with boolean conversion', () => {
+    const text = `<poml>
+      <runtime 
+        stream="true" 
+        debug="false"
+        enable-logging="true"
+      />
+    </poml>`;
+    const file = new PomlFile(text);
+    file.react();
+    const runtimeParams = file.getRuntimeParameters();
+    expect(runtimeParams).toEqual({
+      stream: true,
+      debug: false,
+      enableLogging: true
+    });
+  });
+
+  test('runtime parameters with number conversion', () => {
+    const text = `<poml>
+      <runtime 
+        temperature="0.7"
+        max-tokens="2000"
+        seed="12345"
+        timeout="30.5"
+      />
+    </poml>`;
+    const file = new PomlFile(text);
+    file.react();
+    const runtimeParams = file.getRuntimeParameters();
+    expect(runtimeParams).toEqual({
+      temperature: 0.7,
+      maxTokens: 2000,
+      seed: 12345,
+      timeout: 30.5
+    });
+  });
+
+  test('runtime parameters with JSON conversion', () => {
+    const text = `<poml>
+      <runtime 
+        stop='["\\n", "END"]'
+        config='{"retry": 3, "timeout": 5000}'
+        metadata='{"user": "test", "session": 123}'
+      />
+    </poml>`;
+    const file = new PomlFile(text);
+    file.react();
+    const runtimeParams = file.getRuntimeParameters();
+    expect(runtimeParams).toEqual({
+      stop: ["\n", "END"],
+      config: { retry: 3, timeout: 5000 },
+      metadata: { user: "test", session: 123 }
+    });
+  });
+
+  test('runtime parameters with mixed types', () => {
+    const text = `<poml>
+      <runtime 
+        model="gpt-4"
+        temperature="0.8"
+        max-output-tokens="1000"
+        stream="true"
+        stop-sequences='["END", "STOP"]'
+        custom-config='{"advanced": true}'
+      />
+    </poml>`;
+    const file = new PomlFile(text);
+    file.react();
+    const runtimeParams = file.getRuntimeParameters();
+    expect(runtimeParams).toEqual({
+      model: "gpt-4",
+      temperature: 0.8,
+      maxOutputTokens: 1000,
+      stream: true,
+      stopSequences: ["END", "STOP"],
+      customConfig: { advanced: true }
+    });
+  });
+
+  test('runtime parameters with invalid JSON fallback to string', () => {
+    const text = `<poml>
+      <runtime 
+        valid-json='["test"]'
+        invalid-json='{"missing": quote}'
+        not-json="just a string"
+      />
+    </poml>`;
+    const file = new PomlFile(text);
+    file.react();
+    const runtimeParams = file.getRuntimeParameters();
+    expect(runtimeParams).toEqual({
+      validJson: ["test"],
+      invalidJson: '{"missing": quote}',  // Falls back to string
+      notJson: "just a string"
     });
   });
 

--- a/packages/poml/util/schema.ts
+++ b/packages/poml/util/schema.ts
@@ -219,6 +219,14 @@ export class ToolsSchema {
   }
 
   /**
+   * Gets all tools in the collection.
+   * @returns An array of all tool schemas
+   */
+  public getTools(): ToolSchema[] {
+    return Array.from(this.tools.values());
+  }
+
+  /**
    * Removes a tool from the collection.
    * @param name The name of the tool to remove
    * @returns true if the tool was removed, false if it didn't exist

--- a/python/tests/test_poml_formats.py
+++ b/python/tests/test_poml_formats.py
@@ -27,7 +27,7 @@ def _create_image(tmp_path: Path) -> Path:
 def test_poml_format_dict(tmp_path: Path):
     img_path = _create_image(tmp_path)
     markup = f'<p>Image <img src="{img_path}" alt="tiny" syntax="multimedia"/></p>'
-    result = poml.poml(markup, format="dict")
+    result = poml.poml(markup, format="message_dict")
     assert result[0]["speaker"] == "human"
     assert result[0]["content"][0] == "Image "
     img = result[0]["content"][1]
@@ -40,7 +40,7 @@ def test_poml_format_pydantic(tmp_path: Path):
     img_path = _create_image(tmp_path)
     markup = f'<p>Image <img src="{img_path}" alt="tiny" syntax="multimedia"/></p>'
     result = poml.poml(markup, format="pydantic")
-    msg = result[0]
+    msg = result.messages[0]
     assert isinstance(msg, PomlMessage)
     assert msg.speaker == "human"
     assert msg.content[0] == "Image "
@@ -54,7 +54,7 @@ def test_poml_format_pydantic(tmp_path: Path):
 def test_poml_format_openai_chat(tmp_path: Path):
     img_path = _create_image(tmp_path)
     markup = f'<p>Image <img src="{img_path}" alt="tiny" syntax="multimedia"/></p>'
-    result = poml.poml(markup, format="openai_chat")
+    result = poml.poml(markup, format="openai_chat")["messages"]
     msg = result[0]
     assert msg["role"] == "user"
     assert msg["content"][0] == {"type": "text", "text": "Image "}
@@ -67,7 +67,7 @@ def test_poml_format_openai_chat(tmp_path: Path):
 def test_poml_format_langchain(tmp_path: Path):
     img_path = _create_image(tmp_path)
     markup = f'<p>Image <img src="{img_path}" alt="tiny" syntax="multimedia"/></p>'
-    result = poml.poml(markup, format="langchain")
+    result = poml.poml(markup, format="langchain")["messages"]
     msg = result[0]
     assert msg["type"] == "human"
     first = msg["data"]["content"][0]
@@ -87,7 +87,7 @@ def test_tool_call_openai_conversion():
     <tool-response id="call_123" name="search">Python is a language.</tool-response>
     </poml>'''
     
-    result = poml.poml(markup, format="openai_chat")
+    result = poml.poml(markup, format="openai_chat")["messages"]
     expected = [
         {"role": "user", "content": "Search for Python"},
         {
@@ -110,7 +110,7 @@ def test_tool_call_langchain_conversion():
     <tool-response id="call_456" name="calculate">4</tool-response>
     </poml>'''
     
-    result = poml.poml(markup, format="langchain")
+    result = poml.poml(markup, format="langchain")["messages"]
     expected = [
         {
             "type": "ai",
@@ -131,4 +131,210 @@ def test_tool_call_langchain_conversion():
             }
         }
     ]
+    assert result == expected
+
+
+def test_message_dict_format():
+    """Test message_dict format returns just messages array"""
+    markup = '<p>Hello world</p>'
+    result = poml.poml(markup, format="message_dict")
+    expected = [{"speaker": "human", "content": "Hello world"}]
+    assert result == expected
+
+
+def test_dict_format_with_schema_tools_runtime():
+    """Test dict format returns full structure with schema, tools, and runtime"""
+    markup = '''<poml>
+    <output-schema>{"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]}</output-schema>
+    <tools>[{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}]</tools>
+    <runtime temperature="0.5" max-tokens="150" />
+    <p>What is AI?</p>
+    </poml>'''
+    
+    result = poml.poml(markup, format="dict")
+    expected = {
+        "messages": [{"speaker": "human", "content": "What is AI?"}],
+        "schema": {"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]},
+        "tools": [{"type": "function", "function": {"name": "search", "parameters": {"type": "object"}}}],
+        "runtime": {"temperature": 0.5, "max-tokens": 150}
+    }
+    assert result == expected
+
+
+def test_openai_chat_with_schema():
+    """Test OpenAI format with JSON schema response format"""
+    markup = '''<poml>
+    <output-schema>{"type": "object", "properties": {"summary": {"type": "string"}}, "required": ["summary"]}</output-schema>
+    <p>Summarize this text</p>
+    </poml>'''
+    
+    result = poml.poml(markup, format="openai_chat")
+    expected = {
+        "messages": [{"role": "user", "content": "Summarize this text"}],
+        "response_format": {
+            "type": "json_schema",
+            "schema": {"type": "object", "properties": {"summary": {"type": "string"}}, "required": ["summary"]},
+            "strict": True
+        }
+    }
+    assert result == expected
+
+
+def test_openai_chat_with_runtime():
+    """Test OpenAI format converts runtime params to snake_case"""
+    markup = '''<poml>
+    <runtime temperature="0.3" max-tokens="100" top-p="0.9" />
+    <p>Hello</p>
+    </poml>'''
+    
+    result = poml.poml(markup, format="openai_chat")
+    expected = {
+        "messages": [{"role": "user", "content": "Hello"}],
+        "temperature": 0.3,
+        "max_tokens": 100,
+        "top_p": 0.9
+    }
+    assert result == expected
+
+
+def test_openai_chat_with_tools():
+    """Test OpenAI format with tool definitions"""
+    markup = '''<poml>
+    <tools>[
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather information",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    }
+                }
+            }
+        }
+    ]</tools>
+    <p>What's the weather?</p>
+    </poml>'''
+    
+    result = poml.poml(markup, format="openai_chat")
+    expected = {
+        "messages": [{"role": "user", "content": "What's the weather?"}],
+        "tools": [{
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather information",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "location": {"type": "string"}
+                    }
+                }
+            }
+        }]
+    }
+    assert result == expected
+
+
+def test_langchain_with_schema_tools_runtime():
+    """Test LangChain format preserves all metadata"""
+    markup = '''<poml>
+    <output-schema>{"type": "object", "properties": {"result": {"type": "number"}}, "required": ["result"]}</output-schema>
+    <tools>[{"type": "function", "function": {"name": "calculate"}}]</tools>
+    <runtime temperature="0.7" />
+    <p>Calculate something</p>
+    </poml>'''
+    
+    result = poml.poml(markup, format="langchain")
+    expected = {
+        "messages": [{"type": "human", "data": {"content": "Calculate something"}}],
+        "schema": {"type": "object", "properties": {"result": {"type": "number"}}, "required": ["result"]},
+        "tools": [{"type": "function", "function": {"name": "calculate"}}],
+        "runtime": {"temperature": 0.7}
+    }
+    assert result == expected
+
+
+def test_pydantic_format_with_full_frame():
+    """Test pydantic format returns PomlFrame with all fields"""
+    markup = '''<poml>
+    <output-schema>{"type": "object"}</output-schema>
+    <tools>[{"type": "function", "function": {"name": "test"}}]</tools>
+    <runtime temperature="0.5" />
+    <p>Test message</p>
+    </poml>'''
+    
+    from poml.api import PomlFrame, PomlMessage
+    
+    result = poml.poml(markup, format="pydantic")
+    assert isinstance(result, PomlFrame)
+    assert len(result.messages) == 1
+    assert isinstance(result.messages[0], PomlMessage)
+    assert result.messages[0].speaker == "human"
+    assert result.messages[0].content == "Test message"
+    
+    # Check metadata fields
+    assert result.output_schema is not None
+    assert result.output_schema["type"] == "object"
+    assert result.tools is not None
+    assert len(result.tools) == 1
+    assert result.runtime is not None
+    assert result.runtime["temperature"] == 0.5
+
+
+def test_mixed_tool_calls_openai():
+    """Test complex tool call scenario in OpenAI format"""
+    markup = '''<poml>
+    <human-msg>Search for Python tutorials</human-msg>
+    <ai-msg>I'll search for Python tutorials for you.</ai-msg>
+    <tool-request id="call_001" name="web_search" parameters="{{ {query: 'Python tutorials beginners'} }}" />
+    <tool-response id="call_001" name="web_search">Found 5 tutorials: 1. Python Basics, 2. Learn Python...</tool-response>
+    <ai-msg>I found 5 Python tutorials for you.</ai-msg>
+    </poml>'''
+    
+    result = poml.poml(markup, format="openai_chat")["messages"]
+    expected = [
+        {"role": "user", "content": "Search for Python tutorials"},
+        {"role": "assistant", "content": "I'll search for Python tutorials for you."},
+        {
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_001",
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "arguments": '{"query": "Python tutorials beginners"}'
+                }
+            }]
+        },
+        {"role": "tool", "content": "Found 5 tutorials: 1. Python Basics, 2. Learn Python...", "tool_call_id": "call_001"},
+        {"role": "assistant", "content": "I found 5 Python tutorials for you."}
+    ]
+    assert result == expected
+
+
+def test_runtime_camel_case_conversion():
+    """Test various runtime parameter name conversions"""
+    markup = '''<poml>
+    <runtime 
+        maxTokens="1000"
+        topP="0.95"
+        frequencyPenalty="0.5"
+        presencePenalty="0.3"
+        stop-sequences='["END", "STOP"]'
+    />
+    <p>Test</p>
+    </poml>'''
+    
+    result = poml.poml(markup, format="openai_chat")
+    expected = {
+        "messages": [{"role": "user", "content": "Test"}],
+        "max_tokens": 1000,
+        "top_p": 0.95,
+        "frequency_penalty": 0.5,
+        "presence_penalty": 0.3,
+        "stop_sequences": ["END", "STOP"]
+    }
     assert result == expected


### PR DESCRIPTION
This pull request introduces enhanced support for template expressions and automatic type conversion in schema and runtime parameter handling for the POML language, along with improved Python API support for tool calls and richer content types. The changes improve flexibility, correctness, and interoperability across both the TypeScript and Python implementations, and are accompanied by thorough documentation and test coverage.

**Template Expression and Schema Handling Improvements:**

- Added support for template expressions in attributes of `<tool-definition>` and `<output-schema>` elements, allowing dynamic generation of tool names, descriptions, and schemas. This is reflected in both the documentation (`standalone.md`) and the implementation in `PomlFile`, including the new `handleTextAsString` helper. [[1]](diffhunk://#diff-66bbb71ab72831743b3fc07d022212b9bfcbfaf2c4771bd88b76dbc24d42edafR476-R510) [[2]](diffhunk://#diff-0d70c4448e0665d7c28f80e590ad8dcb30bcce030ae025fc6962466583b0562bL811-R831) [[3]](diffhunk://#diff-0d70c4448e0665d7c28f80e590ad8dcb30bcce030ae025fc6962466583b0562bR1016-R1028)
- The `lang` attribute of schemas now supports template expressions, enabling dynamic schema language selection.

**Runtime Parameter Handling and Type Conversion:**

- Runtime parameter keys are now automatically converted from kebab-case to camelCase, and values are converted to appropriate types (boolean, number, JSON, or string), both in the implementation and in the documentation. [[1]](diffhunk://#diff-66bbb71ab72831743b3fc07d022212b9bfcbfaf2c4771bd88b76dbc24d42edafL484-R535) [[2]](diffhunk://#diff-0d70c4448e0665d7c28f80e590ad8dcb30bcce030ae025fc6962466583b0562bL849-R905)
- Extensive new tests verify correct parsing, conversion, and template handling for runtime parameters, including edge cases and error fallback.

**Python API: Tool Call and Rich Content Support:**

- Introduced `ContentMultiMediaToolRequest` and `ContentMultiMediaToolResponse` models to represent tool calls and responses in the Python API, and updated the `Speaker` type to include `"tool"`.
- Enhanced the OpenAI chat conversion logic to handle tool call and tool response messages, including proper mapping of tool calls and rich content to OpenAI's expected format.
- Added a new `PomlFrame` model to encapsulate messages, schemas, tools, and runtime parameters in a single object.
- Added `"message_dict"` as a valid output format for the API.

**Utility Improvements:**

- Added a `getTools()` method to `ToolsSchema` for easier access to all defined tools.

These changes collectively make the POML language and its tooling more expressive, robust, and compatible with modern LLM integration patterns.