### PR TITLE
Rename schema lang attribute to parser

### DIFF
--- a/.github/workflows/test-after-publish.yml
+++ b/.github/workflows/test-after-publish.yml
@@ -45,7 +45,7 @@ jobs:
           set -ex
           for poml_file in examples/*.poml; do
             echo "Testing $poml_file"
-            npx poml "$poml_file"
+            npx poml -f "$poml_file"
           done
         shell: bash
 

--- a/docs/language/standalone.md
+++ b/docs/language/standalone.md
@@ -320,10 +320,10 @@ Response schemas define the expected structure of AI-generated responses, ensuri
 
 ### JSON Schema Format
 
-Use the `lang="json"` attribute to specify JSON Schema format:
+Use the `parser="json"` attribute to specify JSON Schema format:
 
 ```xml
-<output-schema lang="json">
+<output-schema parser="json">
   {
     "type": "object",
     "properties": {
@@ -337,10 +337,10 @@ Use the `lang="json"` attribute to specify JSON Schema format:
 
 ### Expression Format
 
-Use the `lang="expr"` attribute (or omit it for auto-detection) to evaluate JavaScript expressions that return schemas:
+Use the `parser="eval"` attribute (or omit it for auto-detection) to evaluate JavaScript expressions that return schemas:
 
 ```xml
-<output-schema lang="expr">
+<output-schema parser="eval">
   z.object({
     name: z.string(),
     age: z.number().optional()
@@ -348,7 +348,7 @@ Use the `lang="expr"` attribute (or omit it for auto-detection) to evaluate Java
 </output-schema>
 ```
 
-When `lang` is omitted, POML auto-detects the format:
+When `parser` is omitted, POML auto-detects the format:
 - If the content starts with `{`, it's treated as JSON
 - Otherwise, it's treated as an expression
 
@@ -360,7 +360,7 @@ JSON schemas support template expressions using `{{ }}` syntax:
 
 ```xml
 <let name="maxAge" value="100" />
-<output-schema lang="json">
+<output-schema parser="json">
   {
     "type": "object",
     "properties": {
@@ -381,7 +381,7 @@ Expression schemas are evaluated as JavaScript code with access to context varia
 
 ```xml
 <let name="fields" value='["name", "email", "age"]' />
-<output-schema lang="expr">
+<output-schema parser="eval">
   z.object(
     Object.fromEntries(fields.map(f => [f, z.string()]))
   )
@@ -423,7 +423,7 @@ Tool registration enables AI models to interact with external functions during c
 ### Expression Format
 
 ```xml
-<tool-definition name="calculate" description="Perform calculation" lang="expr">
+<tool-definition name="calculate" description="Perform calculation" parser="eval">
   z.object({
     operation: z.enum(['add', 'subtract', 'multiply', 'divide']),
     a: z.number(),
@@ -440,7 +440,7 @@ Tool schemas support the same evaluation modes as response schemas:
 
 ```xml
 <let name="maxValue" value="1000" />
-<tool-definition name="calculator" description="Calculate values" lang="json">
+<tool-definition name="calculator" description="Calculate values" parser="json">
   {
     "type": "object",
     "properties": {
@@ -457,7 +457,7 @@ Tool schemas support the same evaluation modes as response schemas:
 
 ```xml
 <let name="supportedOperations" value='["add", "subtract", "multiply", "divide"]' />
-<tool-definition name="calculator" description="Perform mathematical operations" lang="expr">
+<tool-definition name="calculator" description="Perform mathematical operations" parser="eval">
   z.object({
     operation: z.enum(supportedOperations),
     a: z.number(),
@@ -471,7 +471,7 @@ In expression mode, the `z` variable is automatically available for constructing
 **Required attributes for tools:**
 - **name**: Tool identifier (required)
 - **description**: Tool description (optional but recommended)
-- **lang**: Schema language, either "json" or "expr" (optional, auto-detected based on content)
+- **parser**: Schema parser, either "json" or "eval" (optional, auto-detected based on content)
 
 ### Template Expressions in Attributes
 
@@ -480,9 +480,9 @@ Both schemas and tools support template expressions in their attributes:
 ```xml
 <let name="toolName">calculate</let>
 <let name="toolDesc">Perform mathematical calculations</let>
-<let name="schemaLang">json</let>
+<let name="schemaParser">json</let>
 
-<tool-definition name="{{toolName}}" description="{{toolDesc}}" lang="{{schemaLang}}">
+<tool-definition name="{{toolName}}" description="{{toolDesc}}" parser="{{schemaParser}}">
   {
     "type": "object",
     "properties": {
@@ -503,7 +503,7 @@ Similarly for output schemas:
   }
 }
 </let>
-<output-schema lang="json">
+<output-schema parser="json">
 {{ schemaJson }}
 </output-schema>
 ```

--- a/docs/language/standalone.md
+++ b/docs/language/standalone.md
@@ -320,7 +320,7 @@ Response schemas define the expected structure of AI-generated responses, ensuri
 
 ### JSON Schema Format
 
-Use the `parser="json"` attribute to specify JSON Schema format:
+Use the `parser="json"` attribute to specify JSON Schema format. The schema must be a valid [OpenAPI JSON Schema](https://spec.openapis.org/) object.
 
 ```xml
 <output-schema parser="json">
@@ -337,7 +337,7 @@ Use the `parser="json"` attribute to specify JSON Schema format:
 
 ### Expression Format
 
-Use the `parser="eval"` attribute (or omit it for auto-detection) to evaluate JavaScript expressions that return schemas:
+Use the `parser="eval"` attribute (or omit it for auto-detection) to evaluate JavaScript expressions that return schemas. It should return a [Zod](https://zod.dev/) schema objects or a JavaScript object that complies with [OpenAPI JSON Schema standards](https://spec.openapis.org/):
 
 ```xml
 <output-schema parser="eval">

--- a/docs/vscode/features.md
+++ b/docs/vscode/features.md
@@ -78,7 +78,7 @@ The CodeLens evaluation feature works with:
 - **Template Expressions**: Any `{{ expression }}` in your POML content
 - **Variable Definitions**: `<let>` element value attributes
 - **Control Flow**: Expressions in `for` and `if` attributes
-- **Schema Expressions**: Expressions in meta elements with `lang="expr"`
+- **Schema Expressions**: Expressions in meta elements with `parser="eval"`
 
 #### Example
 
@@ -89,7 +89,7 @@ The CodeLens evaluation feature works with:
   
   <p>We have {{ count }} items: {{ items.join(', ') }}</p>
   
-  <output-schema lang="expr">
+  <output-schema parser="eval">
     z.object({
       total: z.number().max(count),
       items: z.array(z.enum(items))

--- a/packages/poml/tests/file.test.tsx
+++ b/packages/poml/tests/file.test.tsx
@@ -313,10 +313,10 @@ describe('templateEngine', () => {
 });
 
 describe('expressionEvaluation', () => {
-  test('captures expression tokens for meta lang="expr"', () => {
+  test('captures expression tokens for meta parser="eval"', () => {
     const text = `<poml>
       <let name="fields" value='["name", "age"]' />
-      <output-schema lang="expr">
+      <output-schema parser="eval">
         z.object({
           name: z.string(),
           age: z.number()
@@ -327,7 +327,7 @@ describe('expressionEvaluation', () => {
     file.react();
     
     const tokens = file.getExpressionTokens();
-    // Should have tokens for: let value attribute and meta expr content
+    // Should have tokens for: let value attribute and meta eval content
     expect(tokens.length).toBeGreaterThanOrEqual(2);
     
     // Find the let value token
@@ -335,7 +335,7 @@ describe('expressionEvaluation', () => {
     expect(letToken).toBeDefined();
     expect(letToken?.type).toBe('expression');
     
-    // Find the output-schema expr token
+    // Find the output-schema eval token
     const metaToken = tokens.find(t => t.expression?.includes('z.object'));
     expect(metaToken).toBeDefined();
     expect(metaToken?.type).toBe('expression');
@@ -353,11 +353,11 @@ describe('expressionEvaluation', () => {
     expect(ErrorCollection.empty()).toBe(true);
   });
 
-  test('tracks meta expr evaluation', () => {
+  test('tracks meta eval evaluation', () => {
     ErrorCollection.clear();
     const text = `<poml>
       <let name="num" value="42" />
-      <output-schema lang="expr">
+      <output-schema parser="eval">
         z.object({ value: z.number().max(num) })
       </output-schema>
     </poml>`;
@@ -566,7 +566,7 @@ describe('lspFeatures', () => {
 describe('meta elements', () => {
   test('responseSchema with JSON', () => {
     const text = `<poml>
-      <output-schema lang="json">
+      <output-schema parser="json">
         {
           "type": "object",
           "properties": {
@@ -662,8 +662,8 @@ describe('meta elements', () => {
   test('multiple responseSchema error', () => {
     ErrorCollection.clear();
     const text = `<poml>
-      <output-schema lang="json">{"type": "string"}</output-schema>
-      <output-schema lang="json">{"type": "number"}</output-schema>
+      <output-schema parser="json">{"type": "string"}</output-schema>
+      <output-schema parser="json">{"type": "number"}</output-schema>
     </poml>`;
     const file = new PomlFile(text);
     file.react();
@@ -853,8 +853,8 @@ describe('meta elements', () => {
     const text = `<poml>
       <let name="fieldName" value="{{ 'username' }}" />
       <let name="maxLength" value="50" />
-      <let name="lang">json</let>
-      <output-schema lang="{{ lang }}">
+      <let name="parser">json</let>
+      <output-schema parser="{{ parser }}">
         {
           "type": "object",
           "properties": {
@@ -901,7 +901,7 @@ describe('meta elements', () => {
       <let name="toolName">calculate</let>
       <let name="toolDescription">Perform mathematical calculations</let>
       <let name="operations" value='["add", "subtract", "multiply", "divide"]' />
-      <tool-definition name="{{toolName}}" description="{{toolDescription}}" lang="json">
+      <tool-definition name="{{toolName}}" description="{{toolDescription}}" parser="json">
         {
           "type": "object",
           "properties": {
@@ -955,9 +955,9 @@ describe('meta elements', () => {
     const text = `<poml>
       <let name="toolName">calculate</let>
       <let name="toolDesc">Perform mathematical calculations</let>
-      <let name="schemaLang">json</let>
-      
-      <tool-definition name="{{toolName}}" description="{{toolDesc}}" lang="{{schemaLang}}">
+      <let name="schemaParser">json</let>
+
+      <tool-definition name="{{toolName}}" description="{{toolDesc}}" parser="{{schemaParser}}">
         {
           "type": "object",
           "properties": {
@@ -996,7 +996,7 @@ describe('meta elements', () => {
         }
       }
       </let>
-      <output-schema lang="json">
+      <output-schema parser="json">
       {{ schemaJson }}
       </output-schema>
     </poml>`;
@@ -1019,7 +1019,7 @@ describe('meta elements', () => {
     ErrorCollection.clear();
     const text = `<poml>
       <let name="maxAge" value="100" />
-      <output-schema lang="json">
+      <output-schema parser="json">
         {
           "type": "object",
           "properties": {
@@ -1056,7 +1056,7 @@ describe('meta elements', () => {
     ErrorCollection.clear();
     const text = `<poml>
       <let name="operations" value='["add", "subtract", "multiply", "divide"]' />
-      <tool-definition name="calculator" description="Math operations" lang="expr">
+      <tool-definition name="calculator" description="Math operations" parser="eval">
         z.object({
           operation: z.enum(operations),
           a: z.number(),
@@ -1081,7 +1081,7 @@ describe('meta elements', () => {
     ErrorCollection.clear();
     const text = `<poml>
       <let name="fields" value='{ "name": "string", "age": "number" }' />
-      <output-schema lang="expr">
+      <output-schema parser="eval">
         z.object({
           name: z.string(),
           age: z.number(),
@@ -1102,7 +1102,7 @@ describe('meta elements', () => {
   test('malformed JSON syntax error', () => {
     ErrorCollection.clear();
     const text = `<poml>
-      <output-schema lang="json">
+      <output-schema parser="json">
         {
           "type": "object",
           "properties": {
@@ -1123,7 +1123,7 @@ describe('meta elements', () => {
   test('invalid expression evaluation error', () => {
     ErrorCollection.clear();
     const text = `<poml>
-      <output-schema lang="expr">
+      <output-schema parser="eval">
         z.object({
           name: z.nonexistent(),
           age: z.number()
@@ -1141,7 +1141,7 @@ describe('meta elements', () => {
   test('invalid OpenAPI schema structure', () => {
     ErrorCollection.clear();
     const text = `<poml>
-      <output-schema lang="json">
+      <output-schema parser="json">
         "not an object"
       </output-schema>
     </poml>`;


### PR DESCRIPTION
## Summary
- switch parser value from `expr` to `eval` for schemas and tools
- document and test the `parser="eval"` attribute for response schemas and tool definitions

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test`
- `pytest python/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a6680bc2fc832e8f318fbef783d1cf