### PR TITLE
docs: add AI chatbot community project

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ If you find POML useful or related to your research, please cite the following p
 
 - [mini-poml-rs](https://github.com/linmx0130/mini-poml-rs) – Experimental Rust-based POML renderer for environments without JavaScript or Python interpreters.
 - [poml-ruby](https://github.com/GhennadiiMir/poml) – Ruby gem implementation of POML for Ruby applications.
+- [ai-chatbot-with-python-and-angular](https://github.com/hereandnowai/ai-chatbot-with-python-and-angular) – A chatbot built with Python and Angular (version 20), utilizing POML for prompting and the Langchain framework. Developed by HERE AND NOW AI.
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,7 @@ Welcome to the Prompt Orchestration Markup Language (POML) documentation.
 
 - [mini-poml-rs](https://github.com/linmx0130/mini-poml-rs) – Experimental Rust-based POML renderer for environments without JavaScript or Python interpreters.
 - [poml-ruby](https://github.com/GhennadiiMir/poml) – Ruby gem implementation of POML for Ruby applications.
+- [ai-chatbot-with-python-and-angular](https://github.com/hereandnowai/ai-chatbot-with-python-and-angular) – A chatbot built with Python and Angular (version 20), utilizing POML for prompting and the Langchain framework. Developed by HERE AND NOW AI.
 
 ## Community
 


### PR DESCRIPTION
## Summary
- add HERE AND NOW AI's Python and Angular chatbot to community projects

## Testing
- `npm run build-webview`
- `npm run build-cli`
- `npm run lint`
- `npm test` *(fails: fetch failed)*
- `python -m pytest python/tests` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68b8e2177bc8832e98bbae5c8b893c4b