### PR TITLE
docs: add Julia SDK to community projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ If you find POML useful or related to your research, please cite the following p
 - [mini-poml-rs](https://github.com/linmx0130/mini-poml-rs) – Experimental Rust-based POML renderer for environments without JavaScript or Python interpreters.
 - [poml-ruby](https://github.com/GhennadiiMir/poml) – Ruby gem implementation of POML for Ruby applications.
 - [ai-chatbot-with-python-and-angular](https://github.com/hereandnowai/ai-chatbot-with-python-and-angular) – A chatbot built with Python and Angular (version 20), utilizing POML for prompting and the Langchain framework. Developed by HERE AND NOW AI.
+- [PomlSDK.jl](https://github.com/imohag9/PomlSDK.jl) – Julia implementation of the POML specification.
 
 ## Contributing
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ Welcome to the Prompt Orchestration Markup Language (POML) documentation.
 - [mini-poml-rs](https://github.com/linmx0130/mini-poml-rs) – Experimental Rust-based POML renderer for environments without JavaScript or Python interpreters.
 - [poml-ruby](https://github.com/GhennadiiMir/poml) – Ruby gem implementation of POML for Ruby applications.
 - [ai-chatbot-with-python-and-angular](https://github.com/hereandnowai/ai-chatbot-with-python-and-angular) – A chatbot built with Python and Angular (version 20), utilizing POML for prompting and the Langchain framework. Developed by HERE AND NOW AI.
+- [PomlSDK.jl](https://github.com/imohag9/PomlSDK.jl) – Julia implementation of the POML specification.
 
 ## Community
 


### PR DESCRIPTION
## Summary
- add PomlSDK.jl to the community projects list in the main README
- mirror the Julia SDK entry in the documentation index so it appears on the docs site

## Testing
- npm run build-webview
- npm run build-cli
- npm run lint
- npm test *(fails: known fetch/network errors when downloading external assets in tests)*
- python -m pytest python/tests *(fails: network access to GitHub blocked when rendering examples)*

------
https://chatgpt.com/codex/tasks/task_e_68cb54f02898832e9afc48619a4d63ea